### PR TITLE
Define storage type per component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(matter_headers
   ${CMAKE_CURRENT_SOURCE_DIR}/include/matter/ecs.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/matter/component.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/include/matter/component/sparse_vector_storage.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/include/matter/component/component_manager.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/include/matter/component/component_traits.hpp

--- a/include/matter/component.hpp
+++ b/include/matter/component.hpp
@@ -1,0 +1,12 @@
+#ifndef MATTER_COMPONENT_HPP_INCLUDED
+#define MATTER_COMPONENT_HPP_INCLUDED
+
+#pragma once
+
+#include "matter/component/component_manager.hpp"
+#include "matter/component/component_traits.hpp"
+#include "matter/component/identifier.hpp"
+#include "matter/component/sparse_vector_storage.hpp"
+#include "matter/component/vector_storage.hpp"
+
+#endif

--- a/include/matter/component/component_traits.hpp
+++ b/include/matter/component/component_traits.hpp
@@ -5,13 +5,16 @@
 
 #include <type_traits>
 
-namespace matter
+namespace matter::traits
 {
-template<typename T, typename = void>
-struct is_component_traits : public std::false_type
-{};
-
-  //template<typename T, typename = std::void_t<
-} // namespace matter
+/**
+ * The component_traits struct should be specialized for each type of component
+ * you wish to use, provided properties should be:
+ *  - storage_type: required storage type
+ *  - meta_type [optional]: meta information for serialization
+ */
+template<typename C>
+struct component_traits;
+} // namespace matter::traits
 
 #endif

--- a/include/matter/component/sparse_vector_storage.hpp
+++ b/include/matter/component/sparse_vector_storage.hpp
@@ -26,7 +26,7 @@ public:
 
     template<typename... Args>
     component_type&
-    emplace(const typename entity_type::id_type& id, Args&&... args) noexcept(
+    emplace(typename entity_type::id_type id, Args&&... args) noexcept(
         noexcept(component_type(std::declval<Args&&>()...)))
     {
         return m_components.emplace_back(id, std::forward<Args>(args)...);

--- a/include/matter/component/vector_storage.hpp
+++ b/include/matter/component/vector_storage.hpp
@@ -1,0 +1,38 @@
+#ifndef MATTER_COMPONENT_VECTOR_STORAGE_HPP_INCLUDED
+#define MATTER_COMPONENT_VECTOR_STORAGE_HPP_INCLUDED
+
+#pragma once
+
+#include <optional>
+#include <vector>
+
+namespace matter
+{
+template<typename Entity, typename T>
+struct vector_storage
+{
+    using component_type = T;
+    using entity_type                  = Entity;
+
+private:
+    std::vector<std::optional<component_type>> m_components;
+
+public:
+    vector_storage() = default;
+
+    template<typename... Args>
+    component_type& emplace(typename entity_type::id_type id, Args&&... args)
+    {
+        // enlarge if necessary
+        if (std::size(m_components) <= id)
+        {
+            m_components.resize(id + 1, {});
+        }
+
+        m_components[id] = T(std::forward<Args>(args)...);
+        return *m_components[id];
+    }
+};
+} // namespace matter
+
+#endif

--- a/test/test_component.cpp
+++ b/test/test_component.cpp
@@ -1,8 +1,6 @@
 #include <catch2/catch.hpp>
 
-#include "matter/component/component_manager.hpp"
-#include "matter/component/identifier.hpp"
-#include "matter/component/sparse_vector.hpp"
+#include "matter/component.hpp"
 #include "matter/entity/entity.hpp"
 #include "matter/entity/entity_manager.hpp"
 

--- a/test/test_component.cpp
+++ b/test/test_component.cpp
@@ -16,6 +16,17 @@ struct random_component
     {}
 };
 
+namespace matter::traits
+{
+template<>
+struct component_traits<random_component>
+{
+    template<typename Entity>
+    using storage_type =
+        matter::sparse_vector_storage<Entity, random_component>;
+};
+} // namespace matter::traits
+
 TEST_CASE("sparse_vector")
 {
     matter::sparse_vector<random_component> vec;
@@ -78,6 +89,23 @@ TEST_CASE("sparse_vector")
         }
     }
 }
+
+namespace matter::traits
+{
+template<>
+struct component_traits<int>
+{
+    template<typename Entity>
+    using storage_type = matter::sparse_vector_storage<Entity, int>;
+};
+
+template<>
+struct component_traits<std::string>
+{
+    template<typename Entity>
+    using storage_type = matter::vector_storage<Entity, std::string>;
+};
+} // namespace matter::traits
 
 TEST_CASE("storage")
 {


### PR DESCRIPTION
Fixes #1 

Through a traits class components can select their required storage type.

```cpp
namespace matter::traits {
template<>
struct component_traits<my_component> {
    template<typename Entity>
    using storage_type = matter::sparse_vector_storage<Entity, 
};  
}
```