### PR TITLE
Component traits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ compile_commands.json
 .vs/
 CMakeSettings.json
 .cquery_cached_index/
+.cquery

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ compile_commands.json
 .kdev4/
 .vs/
 CMakeSettings.json
+.cquery_cached_index/

--- a/include/matter/component/traits.hpp
+++ b/include/matter/component/traits.hpp
@@ -59,6 +59,9 @@ template<typename Component, typename Id, typename = void>
 struct is_component_storage_defined : std::false_type
 {};
 
+/// \brief whether the component has custom storage defined
+/// components with `storage_type` defined will use this instead of the default
+/// predefined storage
 template<typename Component, typename Id>
 struct is_component_storage_defined<
     Component,
@@ -74,6 +77,11 @@ template<typename Component, typename = void>
 struct is_component_dependent : std::false_type
 {};
 
+/// \brief This component depends on another component's presence
+/// If this component is assigned to an entity then all components specified as
+/// dependency must be present in the entity. This dependency is checked for at
+/// runtime. Dependencies can be specified with `depends_on`.
+/// It is used for a now obsolete optimization.
 template<typename Component>
 struct is_component_dependent<Component, detail::is_dependent_sfinae<Component>>
     : std::true_type
@@ -89,6 +97,8 @@ struct component_depends_on
     using type = std::tuple<typename Component::depends_on>;
 };
 
+/// \brief Get all of this components dependencies.
+/// Returns all dependencies of this component as a tuple.
 template<typename Component>
 struct component_depends_on<
     Component,
@@ -114,6 +124,9 @@ struct is_component<Component, detail::is_component_sfinae<Component>>
 template<typename Component>
 constexpr bool is_component_v = is_component<Component>::value;
 
+/// \brief Check whether dependencies exist
+/// Holds true if all dependencies of the current component are present in the
+/// given component list.
 template<typename Component, typename... Cs>
 struct is_component_depends_present
     : matter::detail::tuple_in_list<component_depends_on_t<Component>, Cs...>
@@ -127,6 +140,9 @@ template<typename Component, typename = void>
 struct is_component_variant : std::false_type
 {};
 
+/// \brief This component is a variant of another
+/// A variant is a variation of a specific tag component. There can only be one
+/// variant of each tag present within the entity.
 template<typename Component>
 struct is_component_variant<Component, detail::is_variant_sfinae<Component>>
     : std::true_type
@@ -160,6 +176,9 @@ template<typename Candidate, typename Component>
 struct if_not_variant_of_void;
 } // namespace detail
 
+/// \brief lists all variants of this tag
+/// Will find all possible variants of the given tag and return them as a tuple
+/// of these variants.
 template<typename Component, typename... Cs>
 struct component_variants
     : detail::merge_non_void<

--- a/include/matter/component/traits.hpp
+++ b/include/matter/component/traits.hpp
@@ -22,6 +22,9 @@ using is_dependent_sfinae = std::void_t<typename Component::depends_on>;
 template<typename Component>
 using is_component_sfinae = std::void_t<std::enable_if_t<
     !detail::is_specialization_of<Component, std::tuple>::value>>;
+
+template<typename Component>
+using is_variant_sfinae = std::void_t<typename Component::variant_of>;
 } // namespace detail
 
 template<typename Component>
@@ -99,6 +102,19 @@ struct is_component_depends_present
 template<typename Component, typename... Cs>
 constexpr bool is_component_depends_present_v =
     is_component_depends_present<Component, Cs...>::value;
+
+template<typename Component, typename = void>
+struct is_component_variant : std::false_type
+{};
+
+template<typename Component>
+struct is_component_variant<Component, detail::is_variant_sfinae<Component>>
+    : std::true_type
+{};
+
+template<typename Component>
+constexpr bool is_component_variant_v = is_component_variant<Component>::value;
+
 } // namespace matter
 
 #endif

--- a/include/matter/component/traits.hpp
+++ b/include/matter/component/traits.hpp
@@ -18,6 +18,10 @@ using is_storage_defined_sfinae =
 
 template<typename Component>
 using is_dependent_sfinae = std::void_t<typename Component::depends_on>;
+
+template<typename Component>
+using is_component_sfinae = std::void_t<std::enable_if_t<
+    !detail::is_specialization_of<Component, std::tuple>::value>>;
 } // namespace detail
 
 template<typename Component>
@@ -71,6 +75,18 @@ struct component_depends_on<
 {
     using type = typename Component::depends_on;
 };
+
+template<typename Component, typename = void>
+struct is_component : std::false_type
+{};
+
+template<typename Component>
+struct is_component<Component, detail::is_component_sfinae<Component>>
+    : std::true_type
+{};
+
+template<typename Component>
+constexpr bool is_component_v = is_component<Component>::value;
 } // namespace matter
 
 #endif

--- a/include/matter/component/traits.hpp
+++ b/include/matter/component/traits.hpp
@@ -130,6 +130,27 @@ template<typename Candidate, typename Component>
 constexpr bool is_component_variant_of_v =
     is_component_variant_of<Candidate, Component>::value;
 
+namespace detail
+{
+/// \brief void if the Candidate is not a variant of the Component
+/// Used for merging using `merge_non_void`, which merges all types that aren't
+/// void, and that's why if a Candidate isn't a variant of Component we want to
+/// return void.
+template<typename Candidate, typename Component>
+struct if_not_variant_of_void;
+} // namespace detail
+
+template<typename Component, typename... Cs>
+struct component_variants
+    : detail::merge_non_void<
+          std::conditional_t<is_component_variant_of_v<Cs, Component>,
+                             Cs,
+                             void>...>
+{};
+
+template<typename Component, typename... Cs>
+using component_variants_t =
+    typename component_variants<Component, Cs...>::type;
 } // namespace matter
 
 #endif

--- a/include/matter/component/traits.hpp
+++ b/include/matter/component/traits.hpp
@@ -115,6 +115,21 @@ struct is_component_variant<Component, detail::is_variant_sfinae<Component>>
 template<typename Component>
 constexpr bool is_component_variant_v = is_component_variant<Component>::value;
 
+template<typename Candidate, typename Component, typename = void>
+struct is_component_variant_of : std::false_type
+{};
+
+template<typename Candidate, typename Component>
+struct is_component_variant_of<Candidate,
+                               Component,
+                               detail::is_variant_sfinae<Candidate>>
+    : std::is_same<typename Candidate::variant_of, Component>
+{};
+
+template<typename Candidate, typename Component>
+constexpr bool is_component_variant_of_v =
+    is_component_variant_of<Candidate, Component>::value;
+
 } // namespace matter
 
 #endif

--- a/include/matter/component/traits.hpp
+++ b/include/matter/component/traits.hpp
@@ -1,0 +1,76 @@
+#ifndef MATTER_COMPONENT_TRAITS_HPP
+#define MATTER_COMPONENT_TRAITS_HPP
+
+#pragma once
+
+#include <tuple>
+#include <type_traits>
+
+#include "matter/util/meta.hpp"
+
+namespace matter
+{
+namespace detail
+{
+template<typename Component, typename Id>
+using is_storage_defined_sfinae =
+    std::void_t<typename Component::template storage_type<Id>>;
+
+template<typename Component>
+using is_dependent_sfinae = std::void_t<typename Component::dependent_on>;
+} // namespace detail
+
+template<typename Component>
+struct is_component_empty
+    : std::integral_constant<bool, (sizeof(Component) <= 1)>
+{};
+
+template<typename Component>
+constexpr bool is_component_empty_v = is_component_empty<Component>::value;
+
+template<typename Component, typename Id, typename = void>
+struct is_component_storage_defined : std::false_type
+{};
+
+template<typename Component, typename Id>
+struct is_component_storage_defined<
+    Component,
+    Id,
+    detail::is_storage_defined_sfinae<Component, Id>> : std::true_type
+{};
+
+template<typename Component, typename Id>
+constexpr bool is_component_storage_defined_v =
+    is_component_storage_defined<Component, Id>::value;
+
+template<typename Component, typename = void>
+struct is_component_dependent : std::false_type
+{};
+
+template<typename Component>
+struct is_component_dependent<Component, detail::is_dependent_sfinae<Component>>
+    : std::false_type
+{};
+
+template<typename Component>
+constexpr bool is_component_dependent_v =
+    is_component_dependent<Component>::value;
+
+template<typename Component, typename = void>
+struct component_depends_on
+{
+    using type = std::tuple<typename Component::depends_on>;
+};
+
+template<typename Component>
+struct component_depends_on<
+    Component,
+    std::void_t<std::enable_if_t<
+        detail::is_specialization_of<typename Component::depends_on,
+                                     std::tuple>::value>>>
+{
+    using type = typename Component::depends_on;
+};
+} // namespace matter
+
+#endif

--- a/include/matter/component/traits.hpp
+++ b/include/matter/component/traits.hpp
@@ -17,7 +17,7 @@ using is_storage_defined_sfinae =
     std::void_t<typename Component::template storage_type<Id>>;
 
 template<typename Component>
-using is_dependent_sfinae = std::void_t<typename Component::dependent_on>;
+using is_dependent_sfinae = std::void_t<typename Component::depends_on>;
 } // namespace detail
 
 template<typename Component>
@@ -49,7 +49,7 @@ struct is_component_dependent : std::false_type
 
 template<typename Component>
 struct is_component_dependent<Component, detail::is_dependent_sfinae<Component>>
-    : std::false_type
+    : std::true_type
 {};
 
 template<typename Component>

--- a/include/matter/component/traits.hpp
+++ b/include/matter/component/traits.hpp
@@ -76,6 +76,9 @@ struct component_depends_on<
     using type = typename Component::depends_on;
 };
 
+template<typename Component>
+using component_depends_on_t = typename component_depends_on<Component>::type;
+
 template<typename Component, typename = void>
 struct is_component : std::false_type
 {};
@@ -87,6 +90,15 @@ struct is_component<Component, detail::is_component_sfinae<Component>>
 
 template<typename Component>
 constexpr bool is_component_v = is_component<Component>::value;
+
+template<typename Component, typename... Cs>
+struct is_component_depends_present
+    : matter::detail::tuple_in_list<component_depends_on_t<Component>, Cs...>
+{};
+
+template<typename Component, typename... Cs>
+constexpr bool is_component_depends_present_v =
+    is_component_depends_present<Component, Cs...>::value;
 } // namespace matter
 
 #endif

--- a/include/matter/component/traits.hpp
+++ b/include/matter/component/traits.hpp
@@ -27,6 +27,26 @@ template<typename Component>
 using is_variant_sfinae = std::void_t<typename Component::variant_of>;
 } // namespace detail
 
+template<typename Component, typename = void>
+struct is_component : std::false_type
+{};
+
+/// \brief Detects whether a struct is a valid component
+/// Components must be copy constructible/assignable, and either trivially
+/// copyable/assignable or nothrow move constructible/assignable
+template<typename Component>
+struct is_component<
+    Component,
+    std::enable_if_t<(
+        std::is_nothrow_copy_constructible_v<Component> &&
+        std::is_nothrow_copy_assignable_v<
+            Component>) &&((std::is_trivially_copyable_v<Component> &&
+                            std::is_trivially_assignable_v<Component>) ||
+                           (std::is_nothrow_move_constructible_v<Component> &&
+                            std::is_nothrow_move_assignable_v<Component>) )>>
+    : std::true_type
+{};
+
 template<typename Component>
 struct is_component_empty
     : std::integral_constant<bool, (sizeof(Component) <= 1)>

--- a/include/matter/component/traits.hpp
+++ b/include/matter/component/traits.hpp
@@ -33,14 +33,10 @@ struct is_component : std::false_type
 template<typename Component>
 struct is_component<
     Component,
-    std::enable_if_t<
+    std::enable_if_t<(
         !detail::is_specialization_of<Component, std::tuple>::value &&
-        (std::is_nothrow_copy_constructible_v<Component> &&
-         std::is_nothrow_copy_assignable_v<
-             Component>) &&((std::is_trivially_copyable_v<Component> &&
-                             std::is_trivially_assignable_v<Component>) ||
-                            (std::is_nothrow_move_constructible_v<Component> &&
-                             std::is_nothrow_move_assignable_v<Component>) )>>
+        (std::is_nothrow_copy_constructible_v<Component> ||
+	 std::is_nothrow_move_constructible_v<Component>))>>
     : std::true_type
 {};
 

--- a/include/matter/util/meta.hpp
+++ b/include/matter/util/meta.hpp
@@ -9,7 +9,15 @@ namespace detail
 {
 template<typename T1, typename T2, typename U = void>
 using enable_if_same_t = std::enable_if_t<std::is_same_v<T1, T2>, U>;
-}
+
+template<typename, template<typename...> typename>
+struct is_specialization_of : std::false_type
+{};
+
+template<template<typename...> typename TTemplate, typename... Ts>
+struct is_specialization_of<TTemplate<Ts...>, TTemplate> : std::true_type
+{};
+} // namespace detail
 } // namespace matter
 
 #endif

--- a/include/matter/util/meta.hpp
+++ b/include/matter/util/meta.hpp
@@ -19,6 +19,33 @@ struct is_specialization_of : std::false_type
 template<template<typename...> typename TTemplate, typename... Ts>
 struct is_specialization_of<TTemplate<Ts...>, TTemplate> : std::true_type
 {};
+
+template<typename T, typename... Ts>
+struct type_in_list : std::false_type
+{};
+
+template<typename T, typename TT, typename... Ts>
+struct type_in_list<T, TT, Ts...> : type_in_list<T, Ts...>
+{};
+
+template<typename T, typename... Ts>
+struct type_in_list<T, T, Ts...> : std::true_type
+{};
+
+template<typename T, typename... Ts>
+constexpr bool type_in_list_v = type_in_list<T, Ts...>::value;
+
+template<typename TTup, typename... Ts>
+struct tuple_in_list : std::false_type
+{};
+
+template<typename... T1s, typename... T2s>
+struct tuple_in_list<std::tuple<T1s...>, T2s...>
+    : std::conjunction<type_in_list<T1s, T2s...>...>
+{};
+
+template<typename TTup, typename... Ts>
+constexpr bool tuple_in_list_v = tuple_in_list<TTup, Ts...>::value;
 } // namespace detail
 } // namespace matter
 

--- a/include/matter/util/meta.hpp
+++ b/include/matter/util/meta.hpp
@@ -51,6 +51,38 @@ struct tuple_in_list<std::tuple<T1s...>, T2s...>
 
 template<typename TTup, typename... Ts>
 constexpr bool tuple_in_list_v = tuple_in_list<TTup, Ts...>::value;
+
+namespace impl
+{
+template<typename Tup, typename... Ts>
+struct merge_non_void_impl
+{};
+
+template<typename... Filtered>
+struct merge_non_void_impl<std::tuple<Filtered...>>
+{
+    using type = std::tuple<Filtered...>;
+};
+
+template<typename... Filtered, typename... Ts>
+struct merge_non_void_impl<std::tuple<Filtered...>, void, Ts...>
+    : merge_non_void_impl<std::tuple<Filtered...>, Ts...>
+{};
+
+template<typename... Filtered, typename T, typename... Ts>
+struct merge_non_void_impl<std::tuple<Filtered...>, T, Ts...>
+    : merge_non_void_impl<std::tuple<Filtered..., T>, Ts...>
+{};
+} // namespace impl
+
+/// \brief merge all non `false_type` types into a tuple
+template<typename... Ts>
+struct merge_non_void : impl::merge_non_void_impl<std::tuple<>, Ts...>
+{};
+
+template<typename... Ts>
+using merge_non_void_t = typename merge_non_void<Ts...>::type;
+
 } // namespace detail
 } // namespace matter
 

--- a/include/matter/util/meta.hpp
+++ b/include/matter/util/meta.hpp
@@ -9,9 +9,11 @@ namespace matter
 {
 namespace detail
 {
+/// \brief same as enable_if_t but with is_same check, for void_t
 template<typename T1, typename T2, typename U = void>
 using enable_if_same_t = std::enable_if_t<std::is_same_v<T1, T2>, U>;
 
+/// \brief true if it's a specialization, false otherwise
 template<typename, template<typename...> typename>
 struct is_specialization_of : std::false_type
 {};
@@ -20,6 +22,7 @@ template<template<typename...> typename TTemplate, typename... Ts>
 struct is_specialization_of<TTemplate<Ts...>, TTemplate> : std::true_type
 {};
 
+/// \brief true if we can find `T` in `Ts...`, false otherwise
 template<typename T, typename... Ts>
 struct type_in_list : std::false_type
 {};
@@ -35,6 +38,8 @@ struct type_in_list<T, T, Ts...> : std::true_type
 template<typename T, typename... Ts>
 constexpr bool type_in_list_v = type_in_list<T, Ts...>::value;
 
+/// Check whether all elements of the tuple `TTup` are present in the
+/// provides `Ts...`
 template<typename TTup, typename... Ts>
 struct tuple_in_list : std::false_type
 {};

--- a/include/matter/util/meta.hpp
+++ b/include/matter/util/meta.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 namespace matter
 {
 namespace detail

--- a/test/meson.build
+++ b/test/meson.build
@@ -5,6 +5,7 @@ tests = [
   'ecs',
   'entity',
   'variant',
+  'util',
 ]
 
 catch_lib = static_library(

--- a/test/test_component.cpp
+++ b/test/test_component.cpp
@@ -1,134 +1,35 @@
 #include <catch2/catch.hpp>
 
-#include "matter/component.hpp"
+#include "matter/component/identifier.hpp"
+#include "matter/component/traits.hpp"
 #include "matter/entity/entity.hpp"
 #include "matter/entity/entity_manager.hpp"
+#include "matter/storage/sparse_vector_storage.hpp"
 
 #include <string>
 
 struct random_component
 {
+    template<typename Id>
+    using storage_type = matter::sparse_vector_storage<Id, random_component>;
+
     int i;
 
     random_component(int i) : i{i}
     {}
 };
 
-namespace matter::traits
+struct empty_component
+{};
+
+TEST_CASE("component")
 {
-template<>
-struct component_traits<random_component>
-{
-    template<typename Entity>
-    using storage_type =
-        matter::sparse_vector_storage<Entity, random_component>;
-};
-} // namespace matter::traits
+    static_assert(
+        matter::is_component_storage_defined_v<random_component, uint32_t>);
 
-TEST_CASE("sparse_vector")
-{
-    matter::sparse_vector<random_component> vec;
-
-    SECTION("check invalid")
-    {
-        CHECK(!vec.has_value(0));
-        CHECK(!vec.has_value(1));
-    }
-
-    SECTION("insert")
-    {
-        vec.push_back(0, random_component(0));
-
-        REQUIRE(vec.has_value(0));
-        CHECK(vec[0].i == 0);
-
-        SECTION("remove iterator")
-        {
-            auto it = std::begin(vec);
-            REQUIRE(it->i == 0);
-            REQUIRE(vec.has_value(0));
-
-            vec.erase(it);
-
-            REQUIRE(!vec.has_value(0));
-        }
-
-        SECTION("remove")
-        {
-            vec.erase(0);
-            REQUIRE(!vec.has_value(0));
-        }
-
-        for (int i = 1; i < 10; ++i)
-        {
-            vec.emplace_back(i * 10, i * 10);
-        }
-
-        SECTION("remove shifing")
-        {
-            vec.erase(0);
-            REQUIRE(!vec.has_value(0));
-
-            for (int i = 1; i < 10; ++i)
-            {
-                REQUIRE(vec[i * 10].i == i * 10);
-            }
-        }
-
-        SECTION("swap and pop")
-        {
-            vec.swap_and_pop(0);
-            REQUIRE(!vec.has_value(0));
-
-            for (int i = 1; i < 10; ++i)
-            {
-                REQUIRE(vec[i * 10].i == i * 10);
-            }
-        }
-    }
-}
-
-namespace matter::traits
-{
-template<>
-struct component_traits<int>
-{
-    template<typename Entity>
-    using storage_type = matter::sparse_vector_storage<Entity, int>;
-};
-
-template<>
-struct component_traits<std::string>
-{
-    template<typename Entity>
-    using storage_type = matter::vector_storage<Entity, std::string>;
-};
-} // namespace matter::traits
-
-TEST_CASE("storage")
-{
-    using entity_type = matter::entity<uint32_t, uint32_t>;
-
-    matter::entity_manager<entity_type>    entities;
-    matter::component_manager<entity_type> components;
-
-    SECTION("add storages")
-    {
-        auto& str_store = components.storage<std::string>();
-        auto& int_store = components.storage<int>();
-
-        auto ent1 = entities.create();
-        auto ent2 = entities.create();
-
-        SECTION("create objects")
-        {
-            str_store.emplace(ent1.id(), "ent1");
-            str_store.emplace(ent2.id(), "ent2");
-
-            int_store.emplace(ent1.id(), 1);
-            int_store.emplace(ent2.id(), 2);
-        }
-    }
+    static_assert(matter::is_component_empty_v<empty_component>);
+    static_assert(
+        !matter::is_component_storage_defined_v<empty_component, uint32_t>);
 }
 
 template<int>

--- a/test/test_component.cpp
+++ b/test/test_component.cpp
@@ -47,6 +47,14 @@ TEST_CASE("component")
     {
         static_assert(matter::is_component_empty_v<empty_component>);
     }
+
+    SECTION("depends")
+    {
+        static_assert(
+            matter::is_component_dependent_v<single_depending_struct>);
+        static_assert(matter::is_component_dependent_v<multi_depending_struct>);
+        static_assert(!matter::is_component_dependent_v<empty_component>);
+    }
 }
 
 template<int>

--- a/test/test_component.cpp
+++ b/test/test_component.cpp
@@ -32,6 +32,19 @@ struct multi_depending_struct
     using depends_on = std::tuple<single_depending_struct, empty_component>;
 };
 
+struct variant_group
+{};
+
+struct variant1
+{
+    using variant_of = variant_group;
+};
+
+struct variant2
+{
+    using variant_of = variant_group;
+};
+
 TEST_CASE("component")
 {
     SECTION("is component")
@@ -86,6 +99,12 @@ TEST_CASE("component")
                                                        random_component,
                                                        empty_component>);
         }
+    }
+
+    SECTION("variant")
+    {
+        static_assert(matter::is_component_variant_v<variant1>);
+        static_assert(!matter::is_component_variant_v<variant_group>);
     }
 }
 

--- a/test/test_component.cpp
+++ b/test/test_component.cpp
@@ -34,6 +34,11 @@ struct multi_depending_struct
 
 TEST_CASE("component")
 {
+    SECTION("is component")
+    {
+        static_assert(matter::is_component_v<random_component>);
+        static_assert(!matter::is_component_v<std::tuple<random_component>>);
+    }
     SECTION("storage type")
     {
         static_assert(
@@ -55,11 +60,11 @@ TEST_CASE("component")
         static_assert(matter::is_component_dependent_v<multi_depending_struct>);
         static_assert(!matter::is_component_dependent_v<empty_component>);
 
-	// check that single types are correctly converted to tuple
+        // check that single types are correctly converted to tuple
         static_assert(std::is_same_v<std::tuple<empty_component>,
                                      typename matter::component_depends_on<
                                          single_depending_struct>::type>);
-	// and tuples remain intact
+        // and tuples remain intact
         static_assert(
             std::is_same_v<std::tuple<single_depending_struct, empty_component>,
                            typename matter::component_depends_on<

--- a/test/test_component.cpp
+++ b/test/test_component.cpp
@@ -22,6 +22,16 @@ struct random_component
 struct empty_component
 {};
 
+struct single_depending_struct
+{
+    using depends_on = empty_component;
+};
+
+struct multi_depending_struct
+{
+    using depends_on = std::tuple<single_depending_struct, empty_component>;
+};
+
 TEST_CASE("component")
 {
     SECTION("storage type")

--- a/test/test_component.cpp
+++ b/test/test_component.cpp
@@ -45,6 +45,11 @@ struct variant2
     using variant_of = variant_group;
 };
 
+struct other_variant
+{
+    using variant_of = empty_component;
+};
+
 TEST_CASE("component")
 {
     SECTION("is component")
@@ -64,6 +69,7 @@ TEST_CASE("component")
     SECTION("empty")
     {
         static_assert(matter::is_component_empty_v<empty_component>);
+        static_assert(!matter::is_component_empty_v<random_component>);
     }
 
     SECTION("depends")
@@ -105,6 +111,22 @@ TEST_CASE("component")
     {
         static_assert(matter::is_component_variant_v<variant1>);
         static_assert(!matter::is_component_variant_v<variant_group>);
+
+        static_assert(
+            matter::is_component_variant_of_v<variant1, variant_group>);
+        static_assert(
+            !matter::is_component_variant_of_v<single_depending_struct,
+                                               variant_group>);
+
+        static_assert(
+            std::is_same_v<matter::component_variants_t<variant_group,
+                                                        single_depending_struct,
+                                                        multi_depending_struct,
+                                                        variant1,
+                                                        other_variant,
+                                                        variant2,
+                                                        int>,
+                           std::tuple<variant1, variant2>>);
     }
 }
 

--- a/test/test_component.cpp
+++ b/test/test_component.cpp
@@ -69,6 +69,23 @@ TEST_CASE("component")
             std::is_same_v<std::tuple<single_depending_struct, empty_component>,
                            typename matter::component_depends_on<
                                multi_depending_struct>::type>);
+
+        SECTION("dependencies validation")
+        {
+            static_assert(
+                matter::is_component_depends_present_v<single_depending_struct,
+                                                       empty_component>);
+            static_assert(
+                !matter::is_component_depends_present_v<single_depending_struct,
+                                                        multi_depending_struct,
+                                                        random_component>);
+
+            static_assert(
+                matter::is_component_depends_present_v<multi_depending_struct,
+                                                       single_depending_struct,
+                                                       random_component,
+                                                       empty_component>);
+        }
     }
 }
 

--- a/test/test_component.cpp
+++ b/test/test_component.cpp
@@ -24,12 +24,19 @@ struct empty_component
 
 TEST_CASE("component")
 {
-    static_assert(
-        matter::is_component_storage_defined_v<random_component, uint32_t>);
+    SECTION("storage type")
+    {
+        static_assert(
+            matter::is_component_storage_defined_v<random_component, uint32_t>);
 
-    static_assert(matter::is_component_empty_v<empty_component>);
-    static_assert(
-        !matter::is_component_storage_defined_v<empty_component, uint32_t>);
+        static_assert(
+            !matter::is_component_storage_defined_v<empty_component, uint32_t>);
+    }
+
+    SECTION("empty")
+    {
+        static_assert(matter::is_component_empty_v<empty_component>);
+    }
 }
 
 template<int>

--- a/test/test_component.cpp
+++ b/test/test_component.cpp
@@ -54,6 +54,16 @@ TEST_CASE("component")
             matter::is_component_dependent_v<single_depending_struct>);
         static_assert(matter::is_component_dependent_v<multi_depending_struct>);
         static_assert(!matter::is_component_dependent_v<empty_component>);
+
+	// check that single types are correctly converted to tuple
+        static_assert(std::is_same_v<std::tuple<empty_component>,
+                                     typename matter::component_depends_on<
+                                         single_depending_struct>::type>);
+	// and tuples remain intact
+        static_assert(
+            std::is_same_v<std::tuple<single_depending_struct, empty_component>,
+                           typename matter::component_depends_on<
+                               multi_depending_struct>::type>);
     }
 }
 

--- a/test/test_storage.cpp
+++ b/test/test_storage.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch.hpp>
 
+#include "matter/storage/sparse_vector.hpp"
 #include "matter/storage/sparse_vector_storage.hpp"
 #include "matter/storage/traits.hpp"
 
@@ -25,7 +26,8 @@ TEST_CASE("sparse_vector_storage")
     static_assert(matter::is_storage_iterable_v<decltype(my_storage)>);
     static_assert(matter::is_storage_const_iterable_v<decltype(my_storage)>);
     static_assert(matter::is_storage_reverse_iterable_v<decltype(my_storage)>);
-    static_assert(matter::is_storage_const_reverse_iterable_v<decltype(my_storage)>);
+    static_assert(
+        matter::is_storage_const_reverse_iterable_v<decltype(my_storage)>);
     static_assert(matter::is_storage_sized_v<decltype(my_storage)>);
     static_assert(matter::is_storage_accessible_v<decltype(my_storage)>);
     static_assert(matter::is_storage_const_accessible_v<decltype(my_storage)>);
@@ -99,6 +101,58 @@ TEST_CASE("sparse_vector_storage")
         {
             auto index = my_storage.index_of(rit);
             validate(index, rit->i);
+        }
+    }
+}
+
+TEST_CASE("sparse_vector")
+{
+    matter::sparse_vector<my_component> vec;
+
+    SECTION("check invalid")
+    {
+        CHECK(!vec.contains(0));
+        CHECK(!vec.contains(1));
+    }
+
+    SECTION("insert")
+    {
+        vec.push_back(0, my_component(0));
+
+        REQUIRE(vec.contains(0));
+        CHECK(vec[0].i == 0);
+
+        SECTION("remove iterator")
+        {
+            auto it = std::begin(vec);
+            REQUIRE(it->i == 0);
+            REQUIRE(vec.contains(0));
+
+            vec.erase(it);
+
+            REQUIRE(!vec.contains(0));
+        }
+
+        SECTION("remove")
+        {
+            vec.erase(0);
+            REQUIRE(!vec.contains(0));
+        }
+
+        for (int i = 1; i < 10; ++i)
+        {
+            vec.emplace_back(i * 10, i * 10);
+        }
+
+        SECTION("remove shifing")
+        {
+            vec.erase(0);
+            REQUIRE(!vec.contains(0));
+
+            for (int i = 1; i < 10; ++i)
+            {
+                REQUIRE(vec[i * 10].i == i * 10);
+            }
         }
     }
 }

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -23,5 +23,7 @@ TEST_CASE("util")
                                             unsigned char,
                                             uint16_t,
                                             uint32_t>);
+
+	static_assert(matter::detail::tuple_in_list_v<std::tuple<>>);
     }
 }

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -24,6 +24,12 @@ TEST_CASE("util")
                                             uint16_t,
                                             uint32_t>);
 
-	static_assert(matter::detail::tuple_in_list_v<std::tuple<>>);
+        static_assert(matter::detail::tuple_in_list_v<std::tuple<>>);
+
+        static_assert(
+            std::is_same_v<
+                matter::detail::
+                    merge_non_void_t<int, float, void, int>,
+                std::tuple<int, float, int>>);
     }
 }

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -1,0 +1,27 @@
+#include <catch2/catch.hpp>
+
+#include "matter/util/meta.hpp"
+
+TEST_CASE("util")
+{
+    SECTION("meta")
+    {
+        static_assert(matter::detail::type_in_list_v<int, float, double, int>);
+        static_assert(
+            !matter::detail::type_in_list_v<char, float, double, int>);
+
+        static_assert(
+            matter::detail::tuple_in_list_v<std::tuple<int, int>, int>);
+        static_assert(!matter::detail::tuple_in_list_v<std::tuple<float, int>,
+                                                       float,
+                                                       char,
+                                                       unsigned char>);
+        static_assert(
+            matter::detail::tuple_in_list_v<std::tuple<unsigned char, uint32_t>,
+                                            float,
+                                            char,
+                                            unsigned char,
+                                            uint16_t,
+                                            uint32_t>);
+    }
+}


### PR DESCRIPTION
Implements various traits for components.
This PR should handle all traits mentioned in #21.
These include:
- #16 `depends_on` trait
A component can be checked for having any dependencies present using `is_component_dependent`. The presence of dependencies can be checked through `is_component_depends_present` using as template parameters the Component and all other components currently known, where it will then check if all contained dependencies can be fulfilled.
- #22 storage type
Components can specify their required storage type with `using storage_type = xx;`. It is not required to set this trait.
- #23 variants
You can define your component to be a variant of a tag by specifying `using variant_of = xx;`. The target component should be empty as it's simply used as a flag in the entities' bitset.
It's possible to retrieve all variants of a tag by using `component_variants_t<tag, comps...>` which will return all known variants of tag in the `comps...` list.
- #24 detect empty component
Components can be checked for being empty/tags by using the `is_component_empty` template, which simply checks whether the sizeof of the component is 1.

- [ x] Documentation