### PR TITLE
Component grouping

### DIFF
--- a/include/matter/component/identifier.hpp
+++ b/include/matter/component/identifier.hpp
@@ -14,7 +14,7 @@ struct identifier
 private:
     static std::atomic<std::size_t> m_next_id;
 
-    template<typename T>
+    template<typename... Ts>
     static std::size_t _get() noexcept
     {
         static const std::size_t id = m_next_id++;
@@ -22,11 +22,11 @@ private:
     }
 
 public:
-    template<typename T>
+    template<typename... Ts>
     static std::size_t get() noexcept
     {
         return _get<typename std::remove_cv<
-            typename std::remove_reference<T>::type>::type>();
+            typename std::remove_reference<Ts>::type>::type...>();
     }
 };
 

--- a/include/matter/component/registry.hpp
+++ b/include/matter/component/registry.hpp
@@ -1,0 +1,139 @@
+#ifndef MATTER_COMPONENT_REGISTRY_HPP
+#define MATTER_COMPONENT_REGISTRY_HPP
+
+#pragma once
+
+#include <algorithm>
+
+#include "component_identifier.hpp"
+
+#include "matter/util/erased.hpp"
+
+namespace matter
+{
+template<typename... Components>
+class registry {
+public:
+    template<std::size_t I>
+    class group {
+    public:
+        static constexpr auto num_components = I;
+
+        using id_type = typename component_identifier<Components...>::id_type;
+
+    private:
+        std::array<std::pair<id_type, erased>, num_components> storage_;
+
+    public:
+        template<typename... Pairs>
+        constexpr group(Pairs&&... id_storage_pairs) noexcept
+            : storage_{std::forward<Pairs>(id_storage_pairs)...}
+        {
+            // passed stores must be sorted by id
+            assert(is_sorted());
+
+            // both of these together make ==, this just gives nicer error
+            // messages.
+            static_assert(sizeof...(Pairs) <= num_components,
+                          "Cannot construct with this many storages.");
+            static_assert(sizeof...(Pairs) >= num_components,
+                          "Cannot construct with this few storages.");
+        }
+
+        constexpr bool contains(id_type id) const noexcept
+        {
+            auto index_it = find_id(id);
+            return index_it != storage_.end();
+        }
+
+        template<typename C>
+        matter::component_storage_t<C>& get(id_type id) noexcept
+        {
+            assert(contains(id));
+            auto index_it = find_id(id);
+            return index_it->second
+                .template get<matter::component_storage_t<C>>();
+        }
+
+        template<typename C>
+        const matter::component_storage_t<C>& get(id_type id) const noexcept
+        {
+            assert(contains(id));
+            auto index_it = find_id(id);
+            return index_it->second
+                .template get<matter::component_storage_t<C>>();
+        }
+
+    private:
+        /// \brief checks whether the stores are sorted
+        constexpr auto is_sorted() const noexcept
+        {
+            return std::is_sorted(storage_.begin(),
+                                  storage_.end(),
+                                  [](const auto& lhs, const auto& rhs) {
+                                      return lhs.first < rhs.first;
+                                  });
+        }
+
+        constexpr auto find_id(id_type id) noexcept
+        {
+            // probably redundant as the id is never changed after construction
+            assert(is_sorted());
+
+            auto index_it =
+                std::lower_bound(storage_.begin(),
+                                 storage_.end(),
+                                 id,
+                                 [](const auto& lhs, const auto& rhs) {
+                                     return lhs.first < rhs;
+                                 });
+
+            if (index_it->first != id)
+            {
+                return storage_.end();
+            }
+
+            return index_it;
+        }
+
+        constexpr auto find_id(id_type id) const noexcept
+        {
+            // probably redundant as the id is never changed after construction
+            assert(is_sorted());
+
+            auto index_it =
+                std::lower_bound(storage_.begin(),
+                                 storage_.end(),
+                                 id,
+                                 [](const auto& lhs, const auto& rhs) {
+                                     return lhs.first < rhs;
+                                 });
+
+            if (index_it->first != id)
+            {
+                return storage_.end();
+            }
+
+            return index_it;
+        }
+    };
+
+public:
+    using identifier_type = component_identifier<Components...>;
+    using id_type         = typename identifier_type::id_type;
+
+private:
+    identifier_type identifier_;
+
+public:
+    constexpr registry() noexcept = default;
+
+    template<typename C>
+    constexpr id_type component_id() const noexcept
+    {
+        return identifier_.template id<C>();
+    }
+};
+} // namespace matter
+
+#endif

--- a/include/matter/util/erased.hpp
+++ b/include/matter/util/erased.hpp
@@ -1,0 +1,97 @@
+#ifndef MATTER_UTIL_ERASED_HPP
+#define MATTER_UTIL_ERASED_HPP
+
+#pragma once
+
+#include <algorithm>
+#include <type_traits>
+#include <utility>
+
+namespace matter
+{
+/// \brief allow erasing a type for generic storage
+/// Upon destruction the destructor of the object will be run.
+/// Unlike `std::any` no mechanism to identify the correct type is provided.
+class erased final {
+public:
+    using deleter_type = std::add_pointer_t<void(void*)>;
+
+private:
+    void*        obj_;
+    deleter_type deleter_;
+
+public:
+    template<typename T, typename... Args>
+    erased(std::in_place_type_t<T>,
+           Args&&... args) noexcept(std::is_nothrow_constructible_v<T, Args...>)
+        : obj_{new T(std::forward<Args>(args)...)}, deleter_{[](void* obj) {
+              auto* t = static_cast<T*>(obj);
+              delete t;
+          }}
+    {
+        static_assert(std::is_constructible_v<T, Args...>,
+                      "Cannot construct T from Args...");
+    }
+
+    erased(const erased&) = delete;
+    erased& operator=(const erased&) = delete;
+
+    erased(erased&& other) noexcept
+        : obj_{std::move(other.obj_)}, deleter_{std::move(other.deleter_)}
+    {
+        // ensure we don't delete our object
+        other.obj_ = nullptr;
+    }
+
+    erased& operator=(erased&& other) noexcept
+    {
+        clear();
+        obj_     = other.obj_;
+        deleter_ = other.deleter_;
+
+        other.obj_ = nullptr;
+
+        return *this;
+    }
+
+    ~erased()
+    {
+        clear();
+    }
+
+    bool empty() const noexcept
+    {
+        return obj_ == nullptr;
+    }
+
+    void clear() noexcept
+    {
+        if (!empty())
+        {
+            deleter_(obj_);
+            obj_ = nullptr;
+        }
+    }
+
+    template<typename T>
+    constexpr T& get() noexcept
+    {
+        return *static_cast<T*>(obj_);
+    }
+
+    template<typename T>
+    constexpr const T& get() const noexcept
+    {
+        return *static_cast<T*>(obj_);
+    }
+}; // namespace matter
+
+template<typename T, typename... Args>
+erased make_erased(Args&&... args) noexcept(
+    std::is_nothrow_constructible_v<T, Args...>)
+{
+    return erased{std::in_place_type_t<T>{}, std::forward<Args>(args)...};
+}
+} // namespace matter
+
+#endif

--- a/include/matter/util/meta.hpp
+++ b/include/matter/util/meta.hpp
@@ -113,6 +113,48 @@ struct merge_non_void : impl::merge_non_void_impl<std::tuple<>, Ts...>
 template<typename... Ts>
 using merge_non_void_t = typename merge_non_void<Ts...>::type;
 
+template<std::size_t N, typename... Ts>
+struct nth
+{};
+
+template<std::size_t N, typename T, typename... Ts>
+struct nth<N, T, Ts...> : nth<N - 1, Ts...>
+{};
+
+template<typename T, typename... Ts>
+struct nth<0, T, Ts...>
+{
+    using type = T;
+};
+
+template<std::size_t N, typename... Ts>
+using nth_t = typename nth<N, Ts...>::type;
+
+template<typename T, typename TupArgs>
+struct is_constructible_expand_tuple
+{};
+
+template<typename T, typename... Args>
+struct is_constructible_expand_tuple<T, std::tuple<Args...>>
+    : std::is_constructible<T, Args...>
+{};
+
+template<typename T, typename TupArgs>
+constexpr auto is_constructible_expand_tuple_v =
+    is_constructible_expand_tuple<T, TupArgs>::value;
+
+template<typename T, typename TupArgs>
+struct is_nothrow_constructible_expand_tuple
+{};
+
+template<typename T, typename... Args>
+struct is_nothrow_constructible_expand_tuple<T, std::tuple<Args...>>
+    : std::is_nothrow_constructible<T, Args...>
+{};
+
+template<typename T, typename TupArgs>
+constexpr auto is_nothrow_constructible_expand_tuple_v =
+    is_nothrow_constructible_expand_tuple<T, TupArgs>::value;
 } // namespace detail
 } // namespace matter
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -6,6 +6,7 @@ tests = [
   'entity',
   'variant',
   'util',
+  'erased',
 ]
 
 catch_lib = static_library(

--- a/test/test_component.cpp
+++ b/test/test_component.cpp
@@ -2,6 +2,7 @@
 
 #include "matter/component/component_identifier.hpp"
 #include "matter/component/identifier.hpp"
+#include "matter/component/registry.hpp"
 #include "matter/component/traits.hpp"
 #include "matter/entity/entity.hpp"
 #include "matter/entity/entity_manager.hpp"
@@ -13,8 +14,8 @@ struct random_component
 {
     static constexpr auto name = "random_component";
 
-    template<typename Id>
-    using storage_type = matter::sparse_vector_storage<Id, random_component>;
+    using storage_type =
+        matter::sparse_vector_storage<std::size_t, random_component>;
 
     int i;
 
@@ -62,11 +63,9 @@ TEST_CASE("component")
     }
     SECTION("storage type")
     {
-        static_assert(
-            matter::is_component_storage_defined_v<random_component, uint32_t>);
+        static_assert(matter::is_component_storage_defined_v<random_component>);
 
-        static_assert(
-            !matter::is_component_storage_defined_v<empty_component, uint32_t>);
+        static_assert(!matter::is_component_storage_defined_v<empty_component>);
     }
 
     SECTION("empty")
@@ -160,6 +159,11 @@ TEST_CASE("component")
               decltype(cident)::constexpr_components_size);
         CHECK(cident.id<std::string_view>() ==
               decltype(cident)::constexpr_components_size + 1);
+    }
+
+    SECTION("registry")
+    {
+        matter::registry<float, int, char> reg;
     }
 }
 

--- a/test/test_erased.cpp
+++ b/test/test_erased.cpp
@@ -1,0 +1,85 @@
+#include <catch2/catch.hpp>
+
+#include <string>
+
+#include "matter/util/erased.hpp"
+
+struct our_test
+{
+    int& i;
+
+    // just to make this struct a bit bigger
+    char c[16]{};
+
+    constexpr our_test(int& i) : i{i}
+    {
+        i += 2;
+    }
+
+    ~our_test()
+    {
+        i += 5;
+    }
+};
+
+TEST_CASE("erased")
+{
+    SECTION("construct")
+    {
+        int i{10};
+
+        matter::erased er{std::in_place_type_t<our_test>{}, i};
+        CHECK(i == 12);
+    }
+
+    SECTION("destructor")
+    {
+        int i{10};
+
+        {
+            matter::erased er = matter::make_erased<our_test>(i);
+            i                 = 10;
+            // at the end of scope destruction should increment by 5
+        }
+
+        CHECK(i == 15);
+    }
+
+    SECTION("get")
+    {
+        int  i  = 0;
+        auto er = matter::make_erased<our_test>(i);
+
+        // i is now 12
+        int& i_ref = er.get<our_test>().i;
+        CHECK(i_ref == i);
+
+        const int& i_const_ref = er.get<our_test>().i;
+        CHECK(i_const_ref == i);
+    }
+
+    SECTION("empty")
+    {
+        auto er = matter::make_erased<std::string>("Hello world");
+        CHECK(!er.empty());
+
+        er.clear();
+        CHECK(er.empty());
+    }
+
+    SECTION("move")
+    {
+        auto er = matter::make_erased<std::string>("hello world");
+        CHECK(!er.empty());
+
+        matter::erased er_move_con{std::move(er)};
+        CHECK(!er_move_con.empty());
+        CHECK(er.empty());
+
+        er = std::move(er_move_con);
+        CHECK(!er.empty());
+        CHECK(er_move_con.empty());
+
+        CHECK(er.get<std::string>().compare("hello world") == 0);
+    }
+}


### PR DESCRIPTION
#30 

`group<I>` is a class which holds a static amount of components `I`. In this group the storage for the components is held. It's held in a generic `erased` type, which handles type erasure. This is a requirement otherwise the possible component combination would lead to combinatoric code bloat. During runtime assertions are used to determine whether the retrieved type really is the one held within `erased`. `erased` itself has no type checking functionality.