### PR TITLE
Implement create operations for the registry

### DIFF
--- a/include/matter/component/component_identifier.hpp
+++ b/include/matter/component/component_identifier.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <unordered_map>
 
 #include "matter/component/identifier.hpp"
@@ -120,6 +121,21 @@ public:
         {
             return id_runtime<Component>();
         }
+    }
+
+    template<typename... Cs>
+    constexpr std::array<id_type, sizeof...(Cs)> ids()
+    {
+        return std::array<id_type, sizeof...(Cs)>{id<Cs>()...};
+    }
+
+    template<typename... Cs>
+    constexpr std::array<id_type, sizeof...(Cs)> sorted_ids()
+    {
+        auto sorted_ids = ids<Cs...>();
+
+        std::sort(sorted_ids.begin(), sorted_ids.end());
+        return sorted_ids;
     }
 };
 } // namespace matter

--- a/include/matter/component/registry.hpp
+++ b/include/matter/component/registry.hpp
@@ -7,7 +7,8 @@
 
 #include "component_identifier.hpp"
 
-#include "matter/util/erased.hpp"
+#include "matter/util/id_erased.hpp"
+#include "matter/util/meta.hpp"
 
 namespace matter
 {
@@ -22,22 +23,160 @@ public:
         using id_type = typename component_identifier<Components...>::id_type;
 
     private:
-        std::array<std::pair<id_type, erased>, num_components> storage_;
+        std::array<matter::id_erased, num_components> storage_;
 
     public:
-        template<typename... Pairs>
-        constexpr group(Pairs&&... id_storage_pairs) noexcept
-            : storage_{std::forward<Pairs>(id_storage_pairs)...}
+        /// \brief construct a new instance of group
+        /// Constructs a group from ids + types, each forwarded as a tuple using
+        /// `forward_as_tuple`. After passing the array will be sorted to ensure
+        /// quick lookup for finding matching ids.
+        template<typename... TupArgs>
+        constexpr group(TupArgs&&... id_erased_args) noexcept
+            : storage_{detail::construct_from_tuple(
+                  std::in_place_type_t<matter::id_erased>{},
+                  std::forward<TupArgs>(id_erased_args))...}
         {
-            // passed stores must be sorted by id
-            assert(is_sorted());
-
-            // both of these together make ==, this just gives nicer error
-            // messages.
-            static_assert(sizeof...(Pairs) <= num_components,
+            static_assert(sizeof...(TupArgs) <= num_components,
                           "Cannot construct with this many storages.");
-            static_assert(sizeof...(Pairs) >= num_components,
+            static_assert(sizeof...(TupArgs) >= num_components,
                           "Cannot construct with this few storages.");
+
+            std::sort(storage_.begin(), storage_.end());
+        }
+
+        /// \brief checks if this group contains the passed ids
+        /// Each passed id must be contained within this group, effectively the
+        /// same as contains but only works on arrays with the same size as the
+        /// group
+        constexpr bool
+        operator==(const std::array<id_type, num_components>& ids) const
+            noexcept
+        {
+            return contains(ids);
+        }
+
+        constexpr bool
+        operator!=(const std::array<id_type, num_components>& ids) const
+            noexcept
+        {
+            return !(*this == ids);
+        }
+
+        /// \brief compares the contained ids
+        /// This function can be used to sort the group in the registry's vector
+        /// for this group size. However doing so is complicated and I have not
+        /// started working on this so far. So these comparison functions remain
+        /// mainly unused for now.
+        template<std::size_t N,
+                 typename = std::enable_if_t<(N <= num_components)>>
+        constexpr bool operator<(const std::array<id_type, N>& ids) const
+            noexcept
+        {
+            assert(std::is_sorted(ids.begin(), ids.end()));
+
+            if constexpr (N == num_components)
+            {
+                for (std::size_t i = 0; i < storage_.size(); ++i)
+                {
+                    if (storage_[i].id() < ids[i])
+                    {
+                        return true;
+                    }
+                    else if (storage_[i].id() > ids[i])
+                    {
+                        return false;
+                    }
+                }
+
+                return false;
+            }
+            else
+            {
+                auto misses = num_components - N;
+
+                for (std::size_t i = 0, j = 0; i < storage_.size(); ++i)
+                {
+                    if (storage_[i].id() < ids[j])
+                    {
+                        // check our allowed misses left
+                        if (misses == 0)
+                        {
+                            return true;
+                        }
+                        else
+                        {
+                            --misses;
+                            continue;
+                            // continue without incrementing j, checking the
+                            // same array[id] next iteration
+                        }
+                    }
+                    else if (storage_[i].id() > ids[j])
+                    {
+                        return false;
+                    }
+
+                    ++j;
+                }
+
+                return false;
+            }
+        }
+
+        constexpr bool
+        operator>(const std::array<id_type, num_components>& ids) const noexcept
+        {
+            assert(std::is_sorted(ids.begin(), ids.end()));
+
+            for (std::size_t i = 0; i < storage_.size(); ++i)
+            {
+                if (storage_[i].id() > ids[i])
+                {
+                    return true;
+                }
+                else if (storage_[i].id() < ids[i])
+                {
+                    return false;
+                }
+            }
+
+            return false;
+        }
+
+        constexpr bool operator<(const group& other) const noexcept
+        {
+            for (std::size_t i = 0; i < storage_.size(); ++i)
+            {
+                if (storage_[i].id() < other.storage_[i].id())
+                {
+                    return true;
+                }
+                else if (storage_[i].id() > other.storage_[i].id())
+                {
+                    return false;
+                }
+            }
+
+            // when equal we get here
+            return false;
+        }
+
+        constexpr bool operator>(const group& other) const noexcept
+        {
+            for (std::size_t i = 0; i < storage_.size(); ++i)
+            {
+                if (storage_[i].id() > other.storage_[i].id())
+                {
+                    return true;
+                }
+                else if (storage_[i].id() < other.storage_[i].id())
+                {
+                    return false;
+                }
+            }
+
+            // when equal we get here
+            return false;
         }
 
         constexpr bool contains(id_type id) const noexcept
@@ -46,13 +185,23 @@ public:
             return index_it != storage_.end();
         }
 
+        template<std::size_t N,
+                 typename = std::enable_if_t<(N <= num_components)>>
+        constexpr bool contains(const std::array<id_type, N>& ids) const
+            noexcept
+        {
+            assert(std::is_sorted(ids.begin(), ids.end()));
+
+            return std::includes(
+                storage_.begin(), storage_.end(), ids.begin(), ids.end());
+        }
+
         template<typename C>
         matter::component_storage_t<C>& get(id_type id) noexcept
         {
             assert(contains(id));
             auto index_it = find_id(id);
-            return index_it->second
-                .template get<matter::component_storage_t<C>>();
+            return index_it->template get<matter::component_storage_t<C>>();
         }
 
         template<typename C>
@@ -60,19 +209,14 @@ public:
         {
             assert(contains(id));
             auto index_it = find_id(id);
-            return index_it->second
-                .template get<matter::component_storage_t<C>>();
+            return index_it->template get<matter::component_storage_t<C>>();
         }
 
     private:
         /// \brief checks whether the stores are sorted
         constexpr auto is_sorted() const noexcept
         {
-            return std::is_sorted(storage_.begin(),
-                                  storage_.end(),
-                                  [](const auto& lhs, const auto& rhs) {
-                                      return lhs.first < rhs.first;
-                                  });
+            return std::is_sorted(storage_.begin(), storage_.end());
         }
 
         constexpr auto find_id(id_type id) noexcept
@@ -81,14 +225,9 @@ public:
             assert(is_sorted());
 
             auto index_it =
-                std::lower_bound(storage_.begin(),
-                                 storage_.end(),
-                                 id,
-                                 [](const auto& lhs, const auto& rhs) {
-                                     return lhs.first < rhs;
-                                 });
+                std::lower_bound(storage_.begin(), storage_.end(), id);
 
-            if (index_it->first != id)
+            if (index_it->id() != id)
             {
                 return storage_.end();
             }
@@ -102,14 +241,9 @@ public:
             assert(is_sorted());
 
             auto index_it =
-                std::lower_bound(storage_.begin(),
-                                 storage_.end(),
-                                 id,
-                                 [](const auto& lhs, const auto& rhs) {
-                                     return lhs.first < rhs;
-                                 });
+                std::lower_bound(storage_.begin(), storage_.end(), id);
 
-            if (index_it->first != id)
+            if (index_it->id() != id)
             {
                 return storage_.end();
             }
@@ -132,6 +266,12 @@ public:
     constexpr id_type component_id() const noexcept
     {
         return identifier_.template id<C>();
+    }
+
+    template<typename C>
+    void register_component() noexcept
+    {
+        identifier_.template register_type<C>();
     }
 };
 } // namespace matter

--- a/include/matter/util/id_erased.hpp
+++ b/include/matter/util/id_erased.hpp
@@ -1,0 +1,177 @@
+#ifndef MATTER_UTIL_ID_ERASED_HPP
+#define MATTER_UTIL_ID_ERASED_HPP
+
+#pragma once
+
+#include "matter/util/erased.hpp"
+
+namespace matter
+{
+class id_erased final {
+public:
+    using id_type = std::size_t;
+
+private:
+    id_type        id_;
+    matter::erased erased_;
+
+public:
+    template<typename T, typename... Args>
+    id_erased(id_type id, std::in_place_type_t<T>, Args&&... args) noexcept(
+        std::is_nothrow_constructible_v<erased,
+                                        std::in_place_type_t<T>,
+                                        Args&&...>)
+        : id_{id}, erased_{std::in_place_type_t<T>{},
+                           std::forward<Args>(args)...}
+    {}
+
+    id_erased(id_erased&& other) noexcept
+        : id_{std::move(other.id_)}, erased_{std::move(other.erased_)}
+    {}
+
+    id_erased& operator=(id_erased&& other) noexcept
+    {
+        id_     = std::move(other.id_);
+        erased_ = std::move(other.erased_);
+
+        return *this;
+    }
+
+    constexpr id_type id() const noexcept
+    {
+        return id_;
+    }
+
+    bool empty() const noexcept
+    {
+        return erased_.empty();
+    }
+
+    void clear() noexcept
+    {
+        erased_.clear();
+    }
+
+    template<typename T>
+    constexpr T& get() noexcept
+    {
+        return erased_.get<T>();
+    }
+
+    template<typename T>
+    constexpr const T& get() const noexcept
+    {
+        return erased_.get<T>();
+    }
+
+    constexpr bool operator==(const id_erased& other) const noexcept
+    {
+        return id_ == other.id_;
+    }
+
+    constexpr bool operator!=(const id_erased& other) const noexcept
+    {
+        return id_ != other.id_;
+    }
+
+    constexpr bool operator<(const id_erased& other) const noexcept
+    {
+        return id_ < other.id_;
+    }
+
+    constexpr bool operator>(const id_erased& other) const noexcept
+    {
+        return id_ > other.id_;
+    }
+
+    constexpr bool operator<=(const id_erased& other) const noexcept
+    {
+        return id_ <= other.id_;
+    }
+
+    constexpr bool operator>=(const id_erased& other) const noexcept
+    {
+        return id_ >= other.id_;
+    }
+
+    constexpr bool operator==(id_type id) const noexcept
+    {
+        return id_ == id;
+    }
+
+    constexpr bool operator!=(id_type id) const noexcept
+    {
+        return id_ != id;
+    }
+
+    constexpr bool operator<(id_type id) const noexcept
+    {
+        return id_ < id;
+    }
+
+    constexpr bool operator>(id_type id) const noexcept
+    {
+        return id_ > id;
+    }
+
+    constexpr bool operator<=(id_type id) const noexcept
+    {
+        return id_ <= id;
+    }
+
+    constexpr bool operator>=(id_type id) const noexcept
+    {
+        return id_ >= id;
+    }
+
+    friend constexpr bool operator==(id_type          id,
+                                     const id_erased& erased) noexcept;
+    friend constexpr bool operator!=(id_type          id,
+                                     const id_erased& erased) noexcept;
+    friend constexpr bool operator<(id_type          id,
+                                    const id_erased& erased) noexcept;
+    friend constexpr bool operator>(id_type          id,
+                                    const id_erased& erased) noexcept;
+    friend constexpr bool operator<=(id_type          id,
+                                     const id_erased& erased) noexcept;
+    friend constexpr bool operator>=(id_type          id,
+                                     const id_erased& erased) noexcept;
+};
+constexpr bool operator==(id_erased::id_type id,
+                          const id_erased&   erased) noexcept
+{
+    return id == erased.id_;
+}
+
+constexpr bool operator!=(id_erased::id_type id,
+                          const id_erased&   erased) noexcept
+{
+    return id != erased.id_;
+}
+
+constexpr bool operator<(id_erased::id_type id,
+                         const id_erased&   erased) noexcept
+{
+    return id < erased.id_;
+}
+
+constexpr bool operator>(id_erased::id_type id,
+                         const id_erased&   erased) noexcept
+{
+    return id > erased.id_;
+}
+
+constexpr bool operator<=(id_erased::id_type id,
+                          const id_erased&   erased) noexcept
+{
+    return id <= erased.id_;
+}
+
+constexpr bool operator>=(id_erased::id_type id,
+                          const id_erased&   erased) noexcept
+{
+    return id >= erased.id_;
+}
+} // namespace matter
+
+#endif

--- a/include/matter/util/meta.hpp
+++ b/include/matter/util/meta.hpp
@@ -10,6 +10,30 @@ namespace matter
 {
 namespace detail
 {
+namespace impl
+{
+template<typename T, std::size_t... Is, typename... Args>
+constexpr T construct_from_tuple_impl(
+    std::index_sequence<Is...>,
+    std::in_place_type_t<T>,
+    std::tuple<Args...>
+        targs) noexcept(std::is_nothrow_constructible_v<T, Args...>)
+{
+    return T(std::forward<Args>(std::get<Is>(targs))...);
+}
+} // namespace impl
+
+/// \brief create T from a forward_as_tuple
+template<typename T, typename TupArgs>
+constexpr T construct_from_tuple(std::in_place_type_t<T>,
+                                 TupArgs&& targs) noexcept
+{
+    return impl::construct_from_tuple_impl(
+        std::make_index_sequence<std::tuple_size<TupArgs>::value>{},
+        std::in_place_type_t<T>{},
+        std::forward<TupArgs>(targs));
+}
+
 /// \brief same as enable_if_t but with is_same check, for void_t
 template<typename T1, typename T2, typename U = void>
 using enable_if_same_t = std::enable_if_t<std::is_same_v<T1, T2>, U>;

--- a/test/test_registry.cpp
+++ b/test/test_registry.cpp
@@ -9,11 +9,17 @@
 struct float_comp
 {
     float f;
+
+    constexpr float_comp(float f) : f{f}
+    {}
 };
 
 struct int_comp
 {
     int i;
+
+    constexpr int_comp(int i) : i{i}
+    {}
 };
 
 struct string_comp
@@ -91,6 +97,12 @@ TEST_CASE("registry")
     SECTION("register")
     {
         reg.register_component<std::string>();
+        reg.create<std::string>(std::forward_as_tuple("Hello world"));
     }
 
+    SECTION("create")
+    {
+        reg.create<float_comp, int_comp>(std::forward_as_tuple(5.0f),
+                                         std::forward_as_tuple(5));
+    }
 }

--- a/test/test_registry.cpp
+++ b/test/test_registry.cpp
@@ -27,9 +27,9 @@ TEST_CASE("registry")
 
     SECTION("group")
     {
-        auto grp = decltype(reg)::group<1>{std::make_pair(
+        auto grp = decltype(reg)::group<1>{std::forward_as_tuple(
             reg.component_id<int_comp>(),
-            matter::make_erased<matter::component_storage_t<int_comp>>())};
+            std::in_place_type_t<matter::component_storage_t<int_comp>>{})};
 
         CHECK(grp.contains(reg.component_id<int_comp>()));
         CHECK(!grp.contains(10));
@@ -41,4 +41,56 @@ TEST_CASE("registry")
         vector.push_back({5});
         CHECK(vector.size() == 1);
     }
+
+    SECTION("group comparison")
+    {
+        reg.register_component<std::string>();
+        reg.register_component<char>();
+
+        // ids should roughly be 1, 0, 3 -> 0, 1, 3
+        auto grp = decltype(reg)::group<3>{
+            std::forward_as_tuple(
+                reg.component_id<int_comp>(),
+                std::in_place_type_t<matter::component_storage_t<int_comp>>{}),
+            std::forward_as_tuple(
+                reg.component_id<float_comp>(),
+                std::in_place_type_t<
+                    matter::component_storage_t<float_comp>>{}),
+            std::forward_as_tuple(
+                reg.component_id<std::string>(),
+                std::in_place_type_t<
+                    matter::component_storage_t<std::string>>{})};
+
+        SECTION("<")
+        {
+
+            // should be 0, 1, 3 < 0, 1, 4
+            CHECK(grp < std::array{reg.component_id<float_comp>(),
+                                   reg.component_id<int_comp>(),
+                                   reg.component_id<char>()});
+
+            // test a smaller array
+            CHECK(grp < std::array{reg.component_id<char>()});     // 4
+            CHECK(grp < std::array{reg.component_id<float_comp>(), // 0, 4
+                                   reg.component_id<char>()});
+
+            // 0, 1, 3 <-> 0, 3
+            CHECK(!(grp < std::array{reg.component_id<float_comp>(),
+                                     reg.component_id<std::string>()}));
+        }
+
+        SECTION("contains")
+        {
+            // single components
+            CHECK(grp.contains(std::array{reg.component_id<float_comp>()}));
+            CHECK(grp.contains(std::array{reg.component_id<int_comp>()}));
+            CHECK(grp.contains(std::array{reg.component_id<std::string>()}));
+        }
+    }
+
+    SECTION("register")
+    {
+        reg.register_component<std::string>();
+    }
+
 }


### PR DESCRIPTION
Groups were implemented to support the needed requirements to instantiate components and automatically assign the correct group for the created components. The registry will automatically create a new group if there is no suitable group available for the to be registered components. Additionally various comparison operators were implemented on groups for work on the upcoming iterators.