### PR TITLE
Store metadata about runtime components upon registration

### DIFF
--- a/include/matter/component/metadata.hpp
+++ b/include/matter/component/metadata.hpp
@@ -1,0 +1,21 @@
+#ifndef MATTER_COMPONENT_METADATA_HPP
+#define MATTER_COMPONENT_METADATA_HPP
+
+#pragma once
+
+#include <optional>
+#include <string_view>
+
+namespace matter
+{
+struct component_metadata
+{
+    std::optional<const std::string_view> name;
+
+    constexpr component_metadata(std::optional<const std::string_view> name)
+        : name{name}
+    {}
+};
+} // namespace matter
+
+#endif

--- a/include/matter/component/registry.hpp
+++ b/include/matter/component/registry.hpp
@@ -296,6 +296,11 @@ public:
         identifier_.template register_type<C>();
     }
 
+    const matter::component_metadata& component_metadata(id_type id) noexcept
+    {
+        return identifier_.metadata(id);
+    }
+
     template<typename... Cs, typename... TupArgs>
     void create(TupArgs&&... args) noexcept(
         (detail::is_nothrow_constructible_expand_tuple_v<Cs, TupArgs> && ...))

--- a/test/test_component.cpp
+++ b/test/test_component.cpp
@@ -159,6 +159,24 @@ TEST_CASE("component")
               decltype(cident)::constexpr_components_size);
         CHECK(cident.id<std::string_view>() ==
               decltype(cident)::constexpr_components_size + 1);
+
+        SECTION("metadata")
+        {
+            auto id = cident.id<random_component>();
+
+            const auto& metadata1 = cident.metadata(id);
+            CHECK(metadata1.name.has_value());
+
+            CHECK(metadata1.name->compare(
+                      matter::component_name_v<random_component>) == 0);
+
+            // next has no name
+            id = cident.id<std::string_view>();
+
+            const auto& metadata2 = cident.metadata(id);
+
+            CHECK(!metadata2.name.has_value());
+        }
     }
 
     SECTION("registry")


### PR DESCRIPTION
Fixes #34 

Upon registration within the `component_identifier` a call to `generate_metadata<C>` happens, during this time all information about the component is still available and gets stored in a vector.

Whilst we still have access to all this metadata from the `Component` type, this metadata gives us the ability to make a relation between `id -> component info` as if we knew the component type. Currently we only store name for components which have this property set. Later on more things such as serialization functions and others can be stored within.