### PR TITLE
Add size and align metadata, store metadata for constexpr components

### DIFF
--- a/include/matter/component/component_identifier.hpp
+++ b/include/matter/component/component_identifier.hpp
@@ -65,7 +65,7 @@ public:
         auto local_id = next_local_id_++;
         runtime_ids_.emplace(id, local_id);
         // store all available metadata for id -> data relation
-        generate_metadata<Component>();
+        metadata_.emplace_back(std::in_place_type_t<Component>{});
         return local_id;
     }
 
@@ -151,26 +151,6 @@ public:
 
         std::sort(sorted_ids.begin(), sorted_ids.end());
         return sorted_ids;
-    }
-
-private:
-    /// \brief generates metadata for runtime components
-    template<typename Component>
-    void generate_metadata()
-    {
-        std::optional<const std::string_view> name =
-            []() -> std::optional<const std::string_view> {
-            if constexpr (matter::is_component_named_v<Component>)
-            {
-                return matter::component_name_v<Component>;
-            }
-            else
-            {
-                return std::nullopt;
-            }
-        }();
-
-        metadata_.emplace_back(std::move(name));
     }
 };
 } // namespace matter

--- a/include/matter/component/metadata.hpp
+++ b/include/matter/component/metadata.hpp
@@ -6,14 +6,32 @@
 #include <optional>
 #include <string_view>
 
+#include "matter/component/traits.hpp"
+
 namespace matter
 {
 struct component_metadata
 {
     std::optional<const std::string_view> name;
 
-    constexpr component_metadata(std::optional<const std::string_view> name)
-        : name{name}
+    std::size_t size;
+    std::size_t align;
+
+    // serialize, deserialize functions
+
+    template<typename Component>
+    constexpr component_metadata(std::in_place_type_t<Component>) noexcept
+        : name{[]() -> std::optional<std::string_view> {
+              if constexpr (matter::is_component_named_v<Component>)
+              {
+                  return matter::component_name_v<Component>;
+              }
+              else
+              {
+                  return std::nullopt;
+              }
+          }()},
+          size{sizeof(Component)}, align{alignof(Component)}
     {}
 };
 } // namespace matter

--- a/test/test_component.cpp
+++ b/test/test_component.cpp
@@ -169,6 +169,8 @@ TEST_CASE("component")
 
             CHECK(metadata1.name->compare(
                       matter::component_name_v<random_component>) == 0);
+            CHECK(metadata1.size == sizeof(random_component));
+            CHECK(metadata1.align == alignof(random_component));
 
             // next has no name
             id = cident.id<std::string_view>();
@@ -176,6 +178,8 @@ TEST_CASE("component")
             const auto& metadata2 = cident.metadata(id);
 
             CHECK(!metadata2.name.has_value());
+            CHECK(metadata2.size == sizeof(std::string_view));
+            CHECK(metadata2.align == alignof(std::string_view));
         }
     }
 

--- a/test/test_component.cpp
+++ b/test/test_component.cpp
@@ -24,7 +24,9 @@ struct random_component
 };
 
 struct empty_component
-{};
+{
+    static constexpr auto name = "empty_component";
+};
 
 struct single_depending_struct
 {
@@ -142,7 +144,8 @@ TEST_CASE("component")
 
     SECTION("component_identifier")
     {
-        matter::component_identifier<float, int, std::string> cident;
+        matter::component_identifier<float, int, std::string, empty_component>
+            cident;
 
         static_assert(cident.id_constexpr<float>() == 0);
         static_assert(cident.is_constexpr<std::string>());
@@ -162,24 +165,46 @@ TEST_CASE("component")
 
         SECTION("metadata")
         {
-            auto id = cident.id<random_component>();
+            SECTION("static")
+            {
+                // has a name
+                auto id = cident.id<empty_component>();
 
-            const auto& metadata1 = cident.metadata(id);
-            CHECK(metadata1.name.has_value());
+                const auto& metadata1 = cident.metadata(id);
+                CHECK(metadata1.name.has_value());
+                CHECK(metadata1.name->compare(
+                          matter::component_name_v<empty_component>) == 0);
+                CHECK(metadata1.size == sizeof(empty_component));
+                CHECK(metadata1.align == alignof(empty_component));
 
-            CHECK(metadata1.name->compare(
-                      matter::component_name_v<random_component>) == 0);
-            CHECK(metadata1.size == sizeof(random_component));
-            CHECK(metadata1.align == alignof(random_component));
+                id                    = cident.id<std::string>();
+                const auto& metadata2 = cident.metadata(id);
 
-            // next has no name
-            id = cident.id<std::string_view>();
+                CHECK(!metadata2.name.has_value());
+                CHECK(metadata2.size == sizeof(std::string));
+                CHECK(metadata2.align == alignof(std::string));
+            }
+            SECTION("runtime")
+            {
+                auto id = cident.id<random_component>();
 
-            const auto& metadata2 = cident.metadata(id);
+                const auto& metadata1 = cident.metadata(id);
+                CHECK(metadata1.name.has_value());
 
-            CHECK(!metadata2.name.has_value());
-            CHECK(metadata2.size == sizeof(std::string_view));
-            CHECK(metadata2.align == alignof(std::string_view));
+                CHECK(metadata1.name->compare(
+                          matter::component_name_v<random_component>) == 0);
+                CHECK(metadata1.size == sizeof(random_component));
+                CHECK(metadata1.align == alignof(random_component));
+
+                // next has no name
+                id = cident.id<std::string_view>();
+
+                const auto& metadata2 = cident.metadata(id);
+
+                CHECK(!metadata2.name.has_value());
+                CHECK(metadata2.size == sizeof(std::string_view));
+                CHECK(metadata2.align == alignof(std::string_view));
+            }
         }
     }
 


### PR DESCRIPTION
Size and align information are now stored with metadata, I decided to opt out of copy, move and destroy functions being stored in the metadata as I don't see any use for these so far. Serialization and deserialization are not yet part of the metadata interface because it'd introduce a dependency and I'd rather wait for the reflection TS to be implemented.

Additionally metadata for constexpr components has been added because even for these components there's no direct relation between `id` -> `type`. Therefore this metadata is now constructed upon instantiation.