### PR TITLE
Guaranteed static evaluation of static typed_ids

### DIFF
--- a/include/matter/component/component_identifier.hpp
+++ b/include/matter/component/component_identifier.hpp
@@ -76,7 +76,7 @@ public:
     {}
 
     template<typename Component>
-    static constexpr bool is_constexpr() noexcept
+    static constexpr bool is_static() noexcept
     {
         return detail::type_in_list_v<Component, Components...>;
     }
@@ -115,7 +115,7 @@ public:
     template<typename Component>
     constexpr bool is_registered() const noexcept
     {
-        if constexpr (is_constexpr<Component>())
+        if constexpr (is_static<Component>())
         {
             return true;
         }
@@ -126,9 +126,9 @@ public:
 
     /// \brief retrieve the local id for a component
     template<typename Component>
-    constexpr typed_id<id_type, Component, is_constexpr<Component>()> id() const
+    constexpr auto id() const
     {
-        if constexpr (is_constexpr<Component>())
+        if constexpr (is_static<Component>())
         {
             return static_id<Component>();
         }
@@ -154,21 +154,21 @@ public:
 
 private:
     template<typename Component>
-    constexpr typed_id<id_type, Component, true> static_id() const
+    constexpr auto static_id() const noexcept
     {
         static_assert(
-            is_constexpr<Component>(),
+            is_static<Component>(),
             "This component id should be retrieved using runtime_id() instead");
         constexpr auto res =
             detail::type_index<Component, Components...>().value();
-        return typed_id<id_type, Component, true>{res};
+        return typed_id<id_type, Component, res>{res};
     }
 
     template<typename Component>
-    typed_id<id_type, Component, false> runtime_id() const
+    constexpr auto runtime_id() const
     {
         static_assert(
-            !is_constexpr<Component>(),
+            !is_static<Component>(),
             "This component id should be retrieve using static_id() instead");
         auto id = identifier_type::template get<Component>();
 
@@ -181,7 +181,9 @@ private:
                 std::in_place_type_t<Component>{}};
         }
 
-        return typed_id<id_type, Component, false>{it->second};
+        return typed_id<id_type,
+                        Component,
+                        std::numeric_limits<id_type>::max()>{it->second};
     }
 };
 } // namespace matter

--- a/include/matter/component/group_vector.hpp
+++ b/include/matter/component/group_vector.hpp
@@ -180,7 +180,7 @@ public:
             return true;
         }());
 
-        std::array<matter::id_erased, ids.size()> groups{matter::id_erased{
+        std::array<matter::id_erased, sizeof...(Ts)> groups{matter::id_erased{
             ids.template get<Ts>(),
             std::in_place_type_t<
                 matter::component_storage_t<typename Ts::type>>{}}...};

--- a/include/matter/component/registry.hpp
+++ b/include/matter/component/registry.hpp
@@ -85,7 +85,7 @@ private:
              matter::component_storage_t<typename Ts::type>> &&
          ...))
     {
-        assert(!find_group_from_ids(ids));
+        assert(!find_group_from_ids(ordered_typed_ids{ids}));
 
         auto& vec            = get_group_vector(ids.size());
         auto  inserted_group = vec.template emplace(ids);

--- a/include/matter/util/meta.hpp
+++ b/include/matter/util/meta.hpp
@@ -15,7 +15,6 @@ namespace impl
 template<typename T, std::size_t... Is, typename... Args>
 constexpr T construct_from_tuple_impl(
     std::index_sequence<Is...>,
-    std::in_place_type_t<T>,
     std::tuple<Args...>
         targs) noexcept(std::is_nothrow_constructible_v<T, Args...>)
 {
@@ -25,12 +24,10 @@ constexpr T construct_from_tuple_impl(
 
 /// \brief create T from a forward_as_tuple
 template<typename T, typename TupArgs>
-constexpr T construct_from_tuple(std::in_place_type_t<T>,
-                                 TupArgs&& targs) noexcept
+constexpr T construct_from_tuple(TupArgs&& targs) noexcept
 {
-    return impl::construct_from_tuple_impl(
+    return impl::construct_from_tuple_impl<T>(
         std::make_index_sequence<std::tuple_size<TupArgs>::value>{},
-        std::in_place_type_t<T>{},
         std::forward<TupArgs>(targs));
 }
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -7,6 +7,7 @@ tests = [
   'variant',
   'util',
   'erased',
+  'typed_id',
 ]
 
 catch_lib = static_library(

--- a/test/test_component.cpp
+++ b/test/test_component.cpp
@@ -148,9 +148,14 @@ TEST_CASE("component")
             cident;
 
         static_assert(cident.id<float>() == 0);
-        static_assert(cident.is_constexpr<std::string>());
-        static_assert(!cident.is_constexpr<std::string_view>());
+        static_assert(cident.is_static<std::string>());
+        static_assert(!cident.is_static<std::string_view>());
         CHECK(cident.template id<float>() == 0);
+
+        static_assert(
+            matter::is_typed_id_v<decltype(cident.id<std::string>())>);
+
+        static_assert(cident.id<std::string>() == cident.id<std::string>());
 
         // we test whether the global id doesn't affect the local id
         CHECK(!cident.is_registered<std::string_view>()); // this will generate

--- a/test/test_typed_id.cpp
+++ b/test/test_typed_id.cpp
@@ -1,0 +1,70 @@
+#include <catch2/catch.hpp>
+
+#include "matter/component/component_identifier.hpp"
+#include "matter/component/typed_id.hpp"
+
+template<typename T, std::size_t Id = 0>
+using static_typed_id = matter::typed_id<std::size_t, T, Id>;
+
+template<typename T>
+using runtime_typed_id =
+    matter::typed_id<std::size_t, T, std::numeric_limits<std::size_t>::max()>;
+
+TEST_CASE("typed_id")
+{
+    SECTION("basics")
+    {
+        // do typed_ids get identified correctly
+        static_assert(matter::is_typed_id_v<static_typed_id<int>>);
+        static_assert(matter::is_typed_id_v<runtime_typed_id<int>>);
+
+        // is static and runtime correct
+        static_assert(static_typed_id<float>::is_static());
+        static_assert(!runtime_typed_id<float>::is_static());
+    }
+
+    SECTION("contains")
+    {
+        matter::component_identifier<char, int, float, short, long> ident{};
+        ident.register_type<unsigned char>();
+        ident.register_type<double>();
+        ident.register_type<unsigned int>();
+
+        SECTION("same size")
+        {
+            auto unordered1  = ident.ids<char, short, float>();
+            auto unordered2  = ident.ids<short, char, float>();
+            auto rt_unorder1 = ident.ids<unsigned char, double, char>();
+            auto rt_unorder2 = ident.ids<double, unsigned char, char>();
+
+            auto ordered1  = ident.ordered_ids<float, short, char>();
+            auto rt_order1 = ident.ordered_ids<char, unsigned char, double>();
+
+            // static types contains
+            CHECK(ordered1.contains(matter::ordered_typed_ids{unordered1}));
+            CHECK(ordered1.contains(matter::ordered_typed_ids{unordered2}));
+
+            CHECK(!ordered1.contains(matter::ordered_typed_ids{rt_unorder1}));
+            CHECK(!ordered1.contains(matter::ordered_typed_ids{rt_unorder2}));
+
+            // runtime types contains
+            CHECK(rt_order1.contains(matter::ordered_typed_ids{rt_unorder1}));
+            CHECK(rt_order1.contains(matter::ordered_typed_ids{rt_unorder2}));
+
+            CHECK(!rt_order1.contains(matter::ordered_typed_ids{unordered1}));
+            CHECK(!rt_order1.contains(matter::ordered_typed_ids{unordered2}));
+        }
+
+        SECTION("smaller")
+        {
+            auto unordered1 = ident.ids<char, short>();
+            auto no_match   = ident.ids<int, short, float>();
+
+            auto ordered =
+                ident.ordered_ids<char, double, unsigned int, float, short>();
+
+            CHECK(ordered.contains(matter::ordered_typed_ids{unordered1}));
+            CHECK(!ordered.contains(matter::ordered_typed_ids{no_match}));
+        }
+    }
+}


### PR DESCRIPTION
There is still a runtime overhead for knowledge which is already available during compilation time. With this PR I will guarantee compile time evaluation by embedding the static values in strong template types.

Compile time sorting isn't possible yet, but a future pr will add this and more efficient than std::sort sorting for runtime ids.