### PR TITLE
Make components require the is_trivially_copyable trait

### DIFF
--- a/test/bench/insert.cpp
+++ b/test/bench/insert.cpp
@@ -4,11 +4,11 @@
 
 void insert_single_vector(benchmark::State& state)
 {
-  std::vector<int> vec;
+    std::vector<int> vec;
 
-  while(state.KeepRunning())
+    while (state.KeepRunning())
     {
-      vec.emplace_back(42);
+        vec.emplace_back(42);
     }
 }
 
@@ -28,7 +28,7 @@ BENCHMARK(insert_single_first_idx)->Range(1, 1);
 
 void insert_single_dynamic(benchmark::State& state)
 {
-    matter::registry<std::vector<int>, float, char, uint16_t> reg;
+    matter::registry<std::array<int, 16>, float, char, uint16_t> reg;
     reg.register_component<int>();
 
     while (state.KeepRunning())

--- a/test/test_component.cpp
+++ b/test/test_component.cpp
@@ -8,7 +8,7 @@
 #include "matter/entity/entity_manager.hpp"
 #include "matter/storage/sparse_vector_storage.hpp"
 
-#include <string>
+#include <string_view>
 
 struct random_component
 {
@@ -144,28 +144,30 @@ TEST_CASE("component")
 
     SECTION("component_identifier")
     {
-        matter::component_identifier<float, int, std::string, empty_component>
-            cident;
+        matter::
+            component_identifier<float, int, std::string_view, empty_component>
+                cident;
 
         static_assert(cident.id<float>() == 0);
-        static_assert(cident.is_static<std::string>());
-        static_assert(!cident.is_static<std::string_view>());
+        static_assert(cident.is_static<std::string_view>());
+        static_assert(!cident.is_static<std::wstring_view>());
         CHECK(cident.template id<float>() == 0);
 
         static_assert(
             matter::is_typed_id_v<decltype(cident.id<std::string>())>);
 
-        static_assert(cident.id<std::string>() == cident.id<std::string>());
+        static_assert(cident.id<std::string_view>() ==
+                      cident.id<std::string_view>());
 
         // we test whether the global id doesn't affect the local id
-        CHECK(!cident.is_registered<std::string_view>()); // this will generate
-                                                          // a global id
+        CHECK(!cident.is_registered<std::wstring_view>()); // this will generate
+                                                           // a global id
         cident.register_type<random_component>(); // this will generate a local
                                                   // id of num+0
-        cident.register_type<std::string_view>();
+        cident.register_type<std::wstring_view>();
         CHECK(cident.id<random_component>() ==
               decltype(cident)::constexpr_components_size);
-        CHECK(cident.id<std::string_view>() ==
+        CHECK(cident.id<std::wstring_view>() ==
               decltype(cident)::constexpr_components_size + 1);
 
         SECTION("metadata")
@@ -182,12 +184,12 @@ TEST_CASE("component")
                 CHECK(metadata1.size == sizeof(empty_component));
                 CHECK(metadata1.align == alignof(empty_component));
 
-                auto        id2       = cident.id<std::string>();
+                auto        id2       = cident.id<std::string_view>();
                 const auto& metadata2 = cident.metadata(id2);
 
                 CHECK(!metadata2.name.has_value());
-                CHECK(metadata2.size == sizeof(std::string));
-                CHECK(metadata2.align == alignof(std::string));
+                CHECK(metadata2.size == sizeof(std::string_view));
+                CHECK(metadata2.align == alignof(std::string_view));
             }
             SECTION("runtime")
             {


### PR DESCRIPTION
fixes #43 

requiring `trivially_copyable` and `trivially_destructible` gives us good performance guarantees by allowing us to memcpy and disregard destructors. This would make sorting and other operations requiring copies efficient to implement. A further resource storing handle types will be required to hold references to non trivial types for our components. To fulfill the trivially destructible concept a further system will have to be inserted to count references to the held resources and automatically clean up unused resources.