### PR TITLE
Change registry_view syntax

### DIFF
--- a/include/matter/component/registry.hpp
+++ b/include/matter/component/registry.hpp
@@ -42,6 +42,12 @@ public:
                              group_vectors_.end()};
     }
 
+    template<typename... TIds>
+    auto view(const matter::unordered_typed_ids<id_type, TIds...>& ids) noexcept
+    {
+        return registry_view{ids, group_vectors_.begin(), group_vectors_.end()};
+    }
+
     template<typename C>
     constexpr auto component_id() const
     {

--- a/include/matter/component/registry.hpp
+++ b/include/matter/component/registry.hpp
@@ -9,6 +9,7 @@
 
 #include "matter/component/group_vector.hpp"
 #include "matter/component/range.hpp"
+#include "matter/component/registry_view.hpp"
 #include "matter/util/meta.hpp"
 
 namespace matter
@@ -33,14 +34,12 @@ private:
 public:
     constexpr registry() = default;
 
-    const auto& group_vectors() const noexcept
+    template<typename... Cs>
+    auto view() noexcept(false)
     {
-        return group_vectors_;
-    }
-
-    auto& group_vectors() noexcept
-    {
-        return group_vectors_;
+        return registry_view{component_ids<Cs...>(),
+                             group_vectors_.begin(),
+                             group_vectors_.end()};
     }
 
     template<typename C>

--- a/include/matter/component/registry_view.hpp
+++ b/include/matter/component/registry_view.hpp
@@ -5,52 +5,45 @@
 
 #include "matter/component/group_vector_view.hpp"
 #include "matter/component/group_view.hpp"
-#include "matter/component/registry.hpp"
 
 namespace matter
 {
+template<typename... Components>
+class registry;
 
-template<typename Registry, typename UnorderedTypedIds>
+template<typename UnorderedTypedIds>
 struct registry_view;
 
-template<typename Registry, typename... TIds>
-struct registry_view<
-    Registry,
-    matter::unordered_typed_ids<typename Registry::id_type, TIds...>>
+template<typename Id, typename... TIds>
+struct registry_view<matter::unordered_typed_ids<Id, TIds...>>
 {
-    static_assert(matter::is_registry_v<Registry>,
-                  "Registry is not of type registry");
-
-public:
-    using unordered_ids_type =
-        matter::unordered_typed_ids<typename Registry::id_type, TIds...>;
-    using registry_type = Registry;
-    using id_type       = typename Registry::id_type;
+    using id_type            = Id;
+    using unordered_ids_type = matter::unordered_typed_ids<id_type, TIds...>;
 
 private:
     matter::unordered_typed_ids<id_type, TIds...> ids_;
-    std::reference_wrapper<registry_type>         registry_;
+    std::vector<group_vector>::iterator           begin_;
+    std::vector<group_vector>::iterator           end_;
 
 public:
-    constexpr registry_view(const unordered_ids_type& ids, Registry& reg)
-        : ids_{ids}, registry_{reg}
+    constexpr registry_view(const unordered_ids_type&           ids,
+                            std::vector<group_vector>::iterator begin,
+                            std::vector<group_vector>::iterator end) noexcept
+        : ids_{ids}, begin_{begin + unordered_ids_type::size()}, end_{end}
     {}
 
     template<typename Function>
     void for_each(Function f) noexcept(
         std::is_nothrow_invocable_v<Function, typename TIds::type&...>)
     {
-        auto beg = registry_.get().group_vectors().begin() +
-                   unordered_ids_type::size();
-
-        if (beg >= registry_.get().group_vectors().end())
+        if (begin_ >= end_)
         {
             return;
         }
 
         std::for_each(
-            beg,
-            registry_.get().group_vectors().end(),
+            begin_,
+            end_,
             [ids = ids_, f = std::move(f)](group_vector& grp_vec) {
                 matter::group_vector_view view{ids, grp_vec};
                 std::for_each(
@@ -71,13 +64,11 @@ public:
     }
 };
 
-template<typename Registry, typename... TIds>
-registry_view(
-    const matter::unordered_typed_ids<typename Registry::id_type, TIds...>,
-    Registry& reg)
-    ->registry_view<
-        Registry,
-        matter::unordered_typed_ids<typename Registry::id_type, TIds...>>;
+template<typename Id, typename... TIds>
+registry_view(const matter::unordered_typed_ids<Id, TIds...>,
+              std::vector<group_vector>::iterator begin,
+              std::vector<group_vector>::iterator end)
+    ->registry_view<matter::unordered_typed_ids<Id, TIds...>>;
 } // namespace matter
 
 #endif

--- a/test/test_entt.cpp
+++ b/test/test_entt.cpp
@@ -86,8 +86,7 @@ TEST_CASE("benchmarks")
         {
             timer t{"Iterating over 1000000 single components - const"};
 
-            auto pos_view =
-                matter::registry_view{reg.component_ids<position>(), reg};
+            auto pos_view = reg.view<position>();
 
             pos_view.for_each([](const auto&) {});
         }
@@ -96,8 +95,7 @@ TEST_CASE("benchmarks")
         {
             timer t{"Iterating over 1000000 single components - mut"};
 
-            auto pos_view =
-                matter::registry_view{reg.component_ids<position>(), reg};
+            auto pos_view = reg.view<position>();
 
             pos_view.for_each([](position& pos) { pos.x = {}; });
         }
@@ -117,8 +115,7 @@ TEST_CASE("benchmarks")
         {
             timer t{"Iterating over 1000000 double components - const"};
 
-            auto view = matter::registry_view{
-                reg.component_ids<position, velocity>(), reg};
+            auto view = reg.view<position, velocity>();
 
             view.for_each([](const position&, const velocity&) {});
         }
@@ -127,8 +124,7 @@ TEST_CASE("benchmarks")
         {
             timer t{"Iterating over 1000000 double components - mut"};
 
-            auto view = matter::registry_view{
-                reg.component_ids<position, velocity>(), reg};
+            auto view = reg.view<position, velocity>();
 
             view.for_each([](position& pos, velocity& vel) {
                 pos.x = {};
@@ -154,8 +150,7 @@ TEST_CASE("benchmarks")
             timer t{"Iterating over 1000000 double components, only half "
                     "double - const"};
 
-            auto view = matter::registry_view{
-                reg.component_ids<position, velocity>(), reg};
+            auto view = reg.view<position, velocity>();
 
             view.for_each([](const position&, const velocity&) {});
         }
@@ -165,8 +160,7 @@ TEST_CASE("benchmarks")
             timer t{"Iterating over 1000000 double components, only half "
                     "double - const"};
 
-            auto view = matter::registry_view{
-                reg.component_ids<position, velocity>(), reg};
+            auto view = reg.view<position, velocity>();
 
             view.for_each([](position& pos, velocity& vel) {
                 pos.x = {};
@@ -190,8 +184,7 @@ TEST_CASE("benchmarks")
             timer t{
                 "Iterating over 1000000 components, only one has both - const"};
 
-            auto view = matter::registry_view{
-                reg.component_ids<position, velocity>(), reg};
+            auto view = reg.view<position, velocity>();
             view.for_each([](const position&, const velocity&) {});
         }
 
@@ -200,8 +193,7 @@ TEST_CASE("benchmarks")
             timer t{
                 "Iterating over 1000000 components, only one has both - mut"};
 
-            auto view = matter::registry_view{
-                reg.component_ids<position, velocity>(), reg};
+            auto view = reg.view<position, velocity>();
             view.for_each([](position& pos, velocity& vel) {
                 pos.x = {};
                 vel.x = {};

--- a/test/test_registry.cpp
+++ b/test/test_registry.cpp
@@ -132,7 +132,7 @@ TEST_CASE("registry")
 
     SECTION("view")
     {
-        auto view = matter::registry_view{reg.component_ids<float_comp>(), reg};
+        auto view = reg.view<float_comp>();
 
         // empty view
         float f{};
@@ -156,8 +156,7 @@ TEST_CASE("registry")
 
             SECTION("read view")
             {
-                auto fview =
-                    matter::registry_view{reg.component_ids<float_comp>(), reg};
+                auto fview = reg.view<float_comp>();
 
                 auto j = 0;
 
@@ -183,8 +182,7 @@ TEST_CASE("registry")
 
             SECTION("check multiple component views")
             {
-                auto fview =
-                    matter::registry_view{reg.component_ids<float_comp>(), reg};
+                auto fview = reg.view<float_comp>();
 
                 auto j = 0;
                 fview.for_each([&](const float_comp&) { ++j; });
@@ -192,8 +190,7 @@ TEST_CASE("registry")
                 // both the single inserted and double inserted should be found
                 CHECK(j == 20000);
 
-                auto ifview = matter::registry_view{
-                    reg.component_ids<int_comp, float_comp>(), reg};
+                auto ifview = reg.view<int_comp, float_comp>();
 
                 j = 0;
                 ifview.for_each(

--- a/test/test_registry.cpp
+++ b/test/test_registry.cpp
@@ -132,7 +132,8 @@ TEST_CASE("registry")
 
     SECTION("view")
     {
-        auto view = reg.view<float_comp>();
+        auto ids  = reg.component_ids<float_comp>();
+        auto view = reg.view(ids);
 
         // empty view
         float f{};


### PR DESCRIPTION
Change the syntax of obtaining a `registry_view` to `registry.view<>()`. This is more convenient and natural.