### PR TITLE
replace typed_id with a concept for typed_ids

### DIFF
--- a/include/matter/component/any_group.hpp
+++ b/include/matter/component/any_group.hpp
@@ -348,9 +348,11 @@ public:
         return size_;
     }
 
-    template<typename C, id_type V>
-    constexpr bool contains(const typed_id<id_type, C, V>& id) const noexcept
+    template<typename TId>
+    constexpr std::enable_if_t<matter::is_typed_id_v<TId>, bool>
+    contains(const TId& id) const noexcept
     {
+        static_assert(matter::has_same_id_type_v<TId, id_type>);
         auto* ptr = find_id(id);
         return ptr == end() ? false : true;
     }
@@ -368,24 +370,30 @@ public:
         return *this == other;
     }
 
-    template<typename C, id_type V>
-    constexpr matter::component_storage_t<C>&
-    storage(const typed_id<id_type, C, V>& id) noexcept
+    template<typename TId>
+    constexpr std::enable_if_t<matter::is_typed_id_v<TId> &&
+                                   matter::has_same_id_type_v<TId, id_type>,
+                               matter::component_storage_t<typename TId::type>&>
+    storage(const TId& id) noexcept
     {
         assert(contains(id));
 
         auto ptr = find_id(id);
-        return ptr->template get<matter::component_storage_t<C>>();
+        return ptr
+            ->template get<matter::component_storage_t<typename TId::type>>();
     }
 
-    template<typename C, id_type V>
-    const matter::component_storage_t<C>&
-    storage(const typed_id<id_type, C, V>& id) const noexcept
+    template<typename TId>
+    constexpr std::enable_if_t<
+        matter::is_typed_id_v<TId> && matter::has_same_id_type_v<TId, id_type>,
+        const matter::component_storage_t<typename TId::type>&>
+    storage(const TId& id) const noexcept
     {
         assert(contains(id));
 
         auto ptr = find_id(id);
-        return ptr->template get<matter::component_storage_t<C>>();
+        return ptr
+            ->template get<matter::component_storage_t<typename TId::type>>();
     }
 
     template<typename... Ts>
@@ -425,9 +433,11 @@ private:
         return std::is_sorted(ptr_, ptr_ + size_);
     }
 
-    template<typename C, id_type V>
-    matter::id_erased* find_id(const typed_id<id_type, C, V>& id) noexcept
+    template<typename TId>
+    constexpr std::enable_if_t<matter::is_typed_id_v<TId>, matter::id_erased*>
+    find_id(const TId& id) noexcept
     {
+        static_assert(matter::has_same_id_type_v<TId, id_type>);
         auto it = std::lower_bound(begin(), end(), id);
 
         if (it == end() || it->id() != id)
@@ -438,10 +448,12 @@ private:
         return it;
     }
 
-    template<typename C, id_type V>
-    const matter::id_erased* find_id(const typed_id<id_type, C, V>& id) const
-        noexcept
+    template<typename TId>
+    constexpr std::enable_if_t<matter::is_typed_id_v<TId>,
+                               const matter::id_erased*>
+    find_id(const TId& id) const noexcept
     {
+        static_assert(matter::has_same_id_type_v<TId, id_type>);
         auto it = std::lower_bound(begin(), end(), id);
 
         if (it == end() || it->id() != id)

--- a/include/matter/component/component_identifier.hpp
+++ b/include/matter/component/component_identifier.hpp
@@ -161,7 +161,7 @@ private:
             "This component id should be retrieved using runtime_id() instead");
         constexpr auto res =
             detail::type_index<Component, Components...>().value();
-        return typed_id<id_type, Component, res>{res};
+        return matter::static_id<id_type, Component, res>{};
     }
 
     template<typename Component>
@@ -181,9 +181,7 @@ private:
                 std::in_place_type_t<Component>{}};
         }
 
-        return typed_id<id_type,
-                        Component,
-                        std::numeric_limits<id_type>::max()>{it->second};
+        return matter::runtime_id<id_type, Component>{it->second};
     }
 };
 } // namespace matter

--- a/test/test_typed_id.cpp
+++ b/test/test_typed_id.cpp
@@ -19,8 +19,8 @@ TEST_CASE("typed_id")
         static_assert(matter::is_typed_id_v<runtime_typed_id<int>>);
 
         // is static and runtime correct
-        static_assert(static_typed_id<float>::is_static());
-        static_assert(!runtime_typed_id<float>::is_static());
+        static_assert(static_typed_id<float>::is_static);
+        static_assert(!runtime_typed_id<float>::is_static);
     }
 
     SECTION("contains")

--- a/test/test_typed_id.cpp
+++ b/test/test_typed_id.cpp
@@ -4,11 +4,10 @@
 #include "matter/component/typed_id.hpp"
 
 template<typename T, std::size_t Id = 0>
-using static_typed_id = matter::typed_id<std::size_t, T, Id>;
+using static_typed_id = matter::static_id<std::size_t, T, Id>;
 
 template<typename T>
-using runtime_typed_id =
-    matter::typed_id<std::size_t, T, std::numeric_limits<std::size_t>::max()>;
+using runtime_typed_id = matter::runtime_id<std::size_t, T>;
 
 TEST_CASE("typed_id")
 {
@@ -17,10 +16,6 @@ TEST_CASE("typed_id")
         // do typed_ids get identified correctly
         static_assert(matter::is_typed_id_v<static_typed_id<int>>);
         static_assert(matter::is_typed_id_v<runtime_typed_id<int>>);
-
-        // is static and runtime correct
-        static_assert(static_typed_id<float>::is_static);
-        static_assert(!runtime_typed_id<float>::is_static);
     }
 
     SECTION("contains")


### PR DESCRIPTION
`typed_id` has been replaced with a more general `is_typed_id` concept. Additionally `typed_id` has been reimplemented in the form of `static_id` and `runtime_id` for both cases respectively.
constexpr  sorting is no longer available but the benchmark does not show any noticeable degradation in performance.