### PR TITLE
Erased storage

### DIFF
--- a/include/matter/component/any_group.hpp
+++ b/include/matter/component/any_group.hpp
@@ -5,7 +5,7 @@
 
 #include "matter/component/traits.hpp"
 #include "matter/component/typed_id.hpp"
-#include "matter/util/id_erased.hpp"
+#include "matter/storage/erased_storage.hpp"
 
 namespace matter
 {
@@ -13,27 +13,29 @@ namespace detail
 {
 /// \brief a group describes the containers for a tuple of components
 /// A group is a lightweight construct which represents a slice of a
-/// `group_vector`, the `id_erased` contained in the group represent a container
-/// for components identified by the `id` within `id_erased`.
+/// `group_vector`, the `erased_storage` contained in the group represent a
+/// container for components identified by the `id` within `erased_storage`.
 template<bool Const = false>
 class any_group {
 private:
     static constexpr auto is_const = Const;
 
-    using erased_type = std::
-        conditional_t<is_const, const matter::id_erased*, matter::id_erased*>;
-    using erased_type_ref = std::
-        conditional_t<is_const, const matter::id_erased&, matter::id_erased&>;
+    using erased_type     = std::conditional_t<is_const,
+                                           const matter::erased_storage*,
+                                           matter::erased_storage*>;
+    using erased_type_ref = std::conditional_t<is_const,
+                                               const matter::erased_storage&,
+                                               matter::erased_storage&>;
 
     template<bool _Const>
     friend class any_group;
 
 public:
-    using id_type = typename matter::id_erased::id_type;
+    using id_type = typename matter::erased_storage::id_type;
 
-    using const_iterator = const matter::id_erased*;
+    using const_iterator = const matter::erased_storage*;
     using iterator =
-        std::conditional_t<is_const, const_iterator, matter::id_erased*>;
+        std::conditional_t<is_const, const_iterator, matter::erased_storage*>;
 
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
     using reverse_iterator       = std::reverse_iterator<iterator>;
@@ -122,7 +124,7 @@ public:
         return ptr_;
     }
 
-    constexpr const matter::id_erased* data() const noexcept
+    constexpr const matter::erased_storage* data() const noexcept
     {
         return ptr_;
     }
@@ -379,8 +381,7 @@ public:
         assert(contains(id));
 
         auto ptr = find_id(id);
-        return ptr
-            ->template get<matter::component_storage_t<typename TId::type>>();
+        return ptr->template get<typename TId::type>();
     }
 
     template<typename TId>
@@ -392,8 +393,7 @@ public:
         assert(contains(id));
 
         auto ptr = find_id(id);
-        return ptr
-            ->template get<matter::component_storage_t<typename TId::type>>();
+        return ptr->template get<typename TId::type>();
     }
 
     template<typename... Ts>
@@ -426,7 +426,7 @@ public:
 private:
     /// \brief elements in a group must always be sorted
     /// this function is a precondition for most operations to ensure all
-    /// `id_erased` are always sorted, this is required for `std::includes`
+    /// `erased_storage` are always sorted, this is required for `std::includes`
     /// and to efficiently check whether ids are contained within this group
     bool is_sorted() const noexcept
     {
@@ -434,7 +434,8 @@ private:
     }
 
     template<typename TId>
-    constexpr std::enable_if_t<matter::is_typed_id_v<TId>, matter::id_erased*>
+    constexpr std::enable_if_t<matter::is_typed_id_v<TId>,
+                               matter::erased_storage*>
     find_id(const TId& id) noexcept
     {
         static_assert(matter::has_same_id_type_v<TId, id_type>);
@@ -450,7 +451,7 @@ private:
 
     template<typename TId>
     constexpr std::enable_if_t<matter::is_typed_id_v<TId>,
-                               const matter::id_erased*>
+                               const matter::erased_storage*>
     find_id(const TId& id) const noexcept
     {
         static_assert(matter::has_same_id_type_v<TId, id_type>);

--- a/include/matter/component/group_vector.hpp
+++ b/include/matter/component/group_vector.hpp
@@ -9,7 +9,7 @@
 
 #include "matter/component/group.hpp"
 #include "matter/component/typed_id.hpp"
-#include "matter/util/id_erased.hpp"
+#include "matter/storage/erased_storage.hpp"
 #include "matter/util/meta.hpp"
 
 namespace matter
@@ -32,8 +32,8 @@ private:
 
         using vector_iterator_type = std::conditional_t<
             Const,
-            typename std::vector<matter::id_erased>::const_iterator,
-            typename std::vector<matter::id_erased>::iterator>;
+            typename std::vector<matter::erased_storage>::const_iterator,
+            typename std::vector<matter::erased_storage>::iterator>;
 
         using value_type =
             std::conditional_t<Const, const_any_group, any_group>;
@@ -157,7 +157,7 @@ private:
     };
 
 public:
-    using id_type = typename matter::id_erased::id_type;
+    using id_type = typename matter::erased_storage::id_type;
 
     using const_iterator = iterator_<true>;
     using iterator       = iterator_<false>;
@@ -167,8 +167,8 @@ public:
 
 private:
     /// the number of components each group stores
-    const std::size_t              size_;
-    std::vector<matter::id_erased> groups_{};
+    const std::size_t                   size_;
+    std::vector<matter::erased_storage> groups_{};
 
 public:
     explicit group_vector(std::size_t size) : size_{size}
@@ -410,10 +410,8 @@ private:
             return true;
         }()));
 
-        std::array<matter::id_erased, sizeof...(TIds)> stores{matter::id_erased{
-            unordered_ids.template get<TIds>(),
-            std::in_place_type_t<
-                matter::component_storage_t<typename TIds::type>>{}}...};
+        std::array<matter::erased_storage, sizeof...(TIds)> stores{
+            matter::erased_storage{unordered_ids.template get<TIds>()}...};
 
         auto inserted_at =
             groups_.insert(pos.it_,

--- a/include/matter/storage/erased_storage.hpp
+++ b/include/matter/storage/erased_storage.hpp
@@ -1,0 +1,243 @@
+#ifndef MATTER_STORAGE_ERASED_STORAGE_HPP
+#define MATTER_STORAGE_ERASED_STORAGE_HPP
+
+#pragma once
+
+#include "matter/component/traits.hpp"
+#include "matter/component/typed_id.hpp"
+#include "matter/util/id_erased.hpp"
+
+namespace matter
+{
+template<typename Id>
+struct erased_component
+{
+    using id_type = Id;
+
+private:
+    /// id stored for debugging purposes
+    id_type id_;
+    void*   value_;
+
+public:
+    constexpr erased_component(id_type id, void* val) : id_{id}, value_{val}
+    {}
+
+    constexpr id_type id() const noexcept
+    {
+        return id_;
+    }
+
+    constexpr void* get() noexcept
+    {
+        return value_;
+    }
+};
+
+struct erased_storage
+{
+    using id_type    = typename matter::id_erased::id_type;
+    using value_type = erased_component<id_type>;
+    using size_type  = std::size_t;
+
+    using get_function_type =
+        std::add_pointer_t<void*(erased_storage& erased, size_type idx)>;
+    using push_back_function_type =
+        std::add_pointer_t<void(erased_storage&           erased,
+                                erased_component<id_type> comp)>;
+    using erase_function_type =
+        std::add_pointer_t<void(erased_storage& erased, size_type idx)>;
+
+private:
+    matter::id_erased       erased_;
+    get_function_type       get_fn_;
+    push_back_function_type pb_fn_;
+    erase_function_type     erase_fn_;
+
+public:
+    template<typename TId>
+    explicit erased_storage(const TId& tid) noexcept(
+        std::is_nothrow_constructible_v<
+            matter::id_erased,
+            matter::component_storage_t<typename TId::id_type>,
+            std::in_place_type_t<typename TId::type>>)
+        : erased_{tid.value(),
+                  std::in_place_type_t<
+                      matter::component_storage_t<typename TId::type>>{}},
+          get_fn_{[](erased_storage& erased, size_type idx) -> void* {
+              using component_type = typename TId::type;
+              auto& storage =
+                  erased.erased_
+                      .get<matter::component_storage_t<component_type>>();
+              return static_cast<void*>(std::addressof(storage[idx]));
+          }},
+          pb_fn_{[](erased_storage& erased, erased_component<id_type> er_comp) {
+              using component_type = typename TId::type;
+              assert(erased.id() == er_comp.id());
+              auto& storage =
+                  erased.erased_
+                      .get<matter::component_storage_t<component_type>>();
+              auto& comp = *static_cast<component_type*>(er_comp.get());
+              storage.push_back(comp);
+          }},
+          erase_fn_{[](erased_storage& erased, size_type idx) {
+              using component_type = typename TId::type;
+              auto& storage =
+                  erased.erased_
+                      .get<matter::component_storage_t<component_type>>();
+              storage.erase(std::begin(storage) + idx);
+          }}
+    {
+        static_assert(matter::is_typed_id_v<TId>,
+                      "You must use a typed id to construct erased_storage.");
+    }
+
+    template<typename C>
+    constexpr matter::component_storage_t<C>& get() noexcept
+    {
+        return erased_.template get<matter::component_storage_t<C>>();
+    }
+
+    template<typename C>
+    constexpr const matter::component_storage_t<C>& get() const noexcept
+    {
+        return erased_.template get<matter::component_storage_t<C>>();
+    }
+
+    constexpr id_type id() const noexcept
+    {
+        return erased_.id();
+    }
+
+    constexpr erased_component<id_type> operator[](size_type idx) noexcept
+    {
+        return erased_component{erased_.id(), get_fn_(*this, idx)};
+    }
+
+    constexpr void push_back(erased_component<id_type> erased_comp) noexcept
+    {
+        pb_fn_(*this, std::move(erased_comp));
+    }
+
+    constexpr void erase(size_type idx) noexcept
+    {
+        erase_fn_(*this, idx);
+    }
+
+    constexpr auto operator==(const erased_storage& other) const noexcept
+    {
+        return erased_ == other.erased_;
+    }
+
+    constexpr auto operator!=(const erased_storage& other) const noexcept
+    {
+        return !(*this == other);
+    }
+
+    constexpr auto operator<(const erased_storage& other) const noexcept
+    {
+        return erased_ < other.erased_;
+    }
+
+    constexpr auto operator>(const erased_storage& other) const noexcept
+    {
+        return erased_ < other.erased_;
+    }
+
+    constexpr auto operator<=(const erased_storage& other) const noexcept
+    {
+        return erased_ <= other.erased_;
+    }
+
+    constexpr auto operator>=(const erased_storage& other) const noexcept
+    {
+        return erased_ >= other.erased_;
+    }
+
+    constexpr auto operator==(id_type id) const noexcept
+    {
+        return erased_ == id;
+    }
+
+    constexpr auto operator!=(id_type id) const noexcept
+    {
+        return !(*this == id);
+    }
+
+    constexpr auto operator<(id_type id) const noexcept
+    {
+        return erased_ < id;
+    }
+
+    constexpr auto operator>(id_type id) const noexcept
+    {
+        return erased_ > id;
+    }
+
+    constexpr auto operator<=(id_type id) const noexcept
+    {
+        return erased_ <= id;
+    }
+
+    constexpr auto operator>=(id_type id) const noexcept
+    {
+        return erased_ >= id;
+    }
+
+    friend constexpr auto operator==(id_type               id,
+                                     const erased_storage& storage) noexcept
+    {
+        return id == storage.erased_;
+    }
+
+    friend constexpr auto operator!=(id_type               id,
+                                     const erased_storage& storage) noexcept
+    {
+        return !(id == storage);
+    }
+
+    friend constexpr auto operator<(id_type               id,
+                                    const erased_storage& storage) noexcept
+    {
+        return id < storage.erased_;
+    }
+
+    friend constexpr auto operator>(id_type               id,
+                                    const erased_storage& storage) noexcept
+    {
+        return id > storage.erased_;
+    }
+
+    friend constexpr auto operator>=(id_type               id,
+                                     const erased_storage& storage) noexcept
+    {
+        return id >= storage.erased_;
+    }
+
+    friend constexpr auto operator<=(id_type               id,
+                                     const erased_storage& storage) noexcept
+    {
+        return id <= storage.erased_;
+    }
+
+    friend void swap(erased_storage& lhs, erased_storage& rhs) noexcept
+    {
+        using std::swap;
+        swap(lhs.erased_, rhs.erased_);
+
+        auto* tmp1  = lhs.get_fn_;
+        lhs.get_fn_ = rhs.get_fn_;
+        rhs.get_fn_ = tmp1;
+
+        auto* tmp2 = lhs.pb_fn_;
+        lhs.pb_fn_ = rhs.pb_fn_;
+        rhs.pb_fn_ = tmp2;
+
+        auto* tmp3    = lhs.erase_fn_;
+        lhs.erase_fn_ = rhs.erase_fn_;
+        rhs.erase_fn_ = tmp3;
+    }
+};
+} // namespace matter
+
+#endif

--- a/include/matter/util/erased.hpp
+++ b/include/matter/util/erased.hpp
@@ -73,16 +73,26 @@ public:
         }
     }
 
+    constexpr void* get_void() noexcept
+    {
+        return obj_;
+    }
+
+    constexpr const void* get_void() const noexcept
+    {
+        return obj_;
+    }
+
     template<typename T>
     constexpr T& get() noexcept
     {
-        return *static_cast<T*>(obj_);
+        return *static_cast<T*>(get_void());
     }
 
     template<typename T>
     constexpr const T& get() const noexcept
     {
-        return *static_cast<T*>(obj_);
+        return *static_cast<T*>(get_void());
     }
 
     friend void swap(erased& lhs, erased& rhs) noexcept;

--- a/include/matter/util/id_erased.hpp
+++ b/include/matter/util/id_erased.hpp
@@ -52,6 +52,16 @@ public:
         erased_.clear();
     }
 
+    constexpr void* get_void() noexcept
+    {
+        return erased_.get_void();
+    }
+
+    constexpr const void* get_void() const noexcept
+    {
+        return erased_.get_void();
+    }
+
     template<typename T>
     constexpr T& get() noexcept
     {
@@ -66,12 +76,12 @@ public:
 
     constexpr bool operator==(const id_erased& other) const noexcept
     {
-        return id_ == other.id_;
+        return id_ == other.id_ && get_void() == other.get_void();
     }
 
     constexpr bool operator!=(const id_erased& other) const noexcept
     {
-        return id_ != other.id_;
+        return !(*this == other);
     }
 
     constexpr bool operator<(const id_erased& other) const noexcept
@@ -125,61 +135,48 @@ public:
     }
 
     friend constexpr bool operator==(id_type          id,
-                                     const id_erased& erased) noexcept;
+                                     const id_erased& erased) noexcept
+    {
+        return id == erased.id_;
+    }
+
     friend constexpr bool operator!=(id_type          id,
-                                     const id_erased& erased) noexcept;
+                                     const id_erased& erased) noexcept
+    {
+        return id != erased.id_;
+    }
+
     friend constexpr bool operator<(id_type          id,
-                                    const id_erased& erased) noexcept;
+                                    const id_erased& erased) noexcept
+    {
+        return id < erased.id_;
+    }
+
     friend constexpr bool operator>(id_type          id,
-                                    const id_erased& erased) noexcept;
+                                    const id_erased& erased) noexcept
+    {
+        return id > erased.id_;
+    }
+
     friend constexpr bool operator<=(id_type          id,
-                                     const id_erased& erased) noexcept;
+                                     const id_erased& erased) noexcept
+    {
+        return id <= erased.id_;
+    }
+
     friend constexpr bool operator>=(id_type          id,
-                                     const id_erased& erased) noexcept;
-    friend void           swap(id_erased& lhs, id_erased& rhs) noexcept;
+                                     const id_erased& erased) noexcept
+    {
+        return id >= erased.id_;
+    }
+
+    friend void swap(id_erased& lhs, id_erased& rhs) noexcept
+    {
+        using std::swap;
+        swap(lhs.id_, rhs.id_);
+        swap(lhs.erased_, rhs.erased_);
+    }
 };
-constexpr bool operator==(id_erased::id_type id,
-                          const id_erased&   erased) noexcept
-{
-    return id == erased.id_;
-}
-
-constexpr bool operator!=(id_erased::id_type id,
-                          const id_erased&   erased) noexcept
-{
-    return id != erased.id_;
-}
-
-constexpr bool operator<(id_erased::id_type id,
-                         const id_erased&   erased) noexcept
-{
-    return id < erased.id_;
-}
-
-constexpr bool operator>(id_erased::id_type id,
-                         const id_erased&   erased) noexcept
-{
-    return id > erased.id_;
-}
-
-constexpr bool operator<=(id_erased::id_type id,
-                          const id_erased&   erased) noexcept
-{
-    return id <= erased.id_;
-}
-
-constexpr bool operator>=(id_erased::id_type id,
-                          const id_erased&   erased) noexcept
-{
-    return id >= erased.id_;
-}
-
-void swap(id_erased& lhs, id_erased& rhs) noexcept
-{
-    using std::swap;
-    swap(lhs.id_, rhs.id_);
-    swap(lhs.erased_, rhs.erased_);
-}
 } // namespace matter
 
 #endif


### PR DESCRIPTION
Erased storage is a new abstraction on top of `id_erased` which supports the underlying storage's `push_back`, `operator[]` and `erase` functions. To support `erase` a valid implementation of `begin` is required to calculate the correct iterator from the index.