### PR TITLE
Implement Sentinels for various data structures

### DIFF
--- a/include/matter/component/group_view.hpp
+++ b/include/matter/component/group_view.hpp
@@ -5,6 +5,7 @@
 
 #include "matter/component/component_view.hpp"
 #include "matter/component/group.hpp"
+#include "matter/util/iterator.hpp"
 
 namespace matter
 {
@@ -26,7 +27,7 @@ public:
     private:
         template<typename C>
         using storage_iterator_type =
-            typename matter::component_storage_t<C>::iterator;
+            matter::iterator_t<typename matter::component_storage_t<C>>;
 
     private:
         std::tuple<storage_iterator_type<Cs>...> its_;

--- a/include/matter/component/registry_view.hpp
+++ b/include/matter/component/registry_view.hpp
@@ -5,6 +5,7 @@
 
 #include "matter/component/group_vector_view.hpp"
 #include "matter/component/group_view.hpp"
+#include "matter/util/algorithm.hpp"
 
 namespace matter
 {
@@ -41,21 +42,21 @@ public:
             return;
         }
 
-        std::for_each(
+        matter::for_each(
             begin_,
             end_,
             [ids = ids_, f = std::move(f)](group_vector& grp_vec) {
                 matter::group_vector_view view{ids, grp_vec};
-                std::for_each(
+                matter::for_each(
                     view.begin(),
                     view.end(),
                     [f = std::move(f), size = grp_vec.group_size(), ids](
                         auto grp_view) {
-                        std::for_each(grp_view.begin(),
-                                      grp_view.end(),
-                                      [f = std::move(f)](auto comp_view) {
-                                          comp_view.invoke(std::move(f));
-                                      });
+                        matter::for_each(grp_view.begin(),
+                                         grp_view.end(),
+                                         [f = std::move(f)](auto comp_view) {
+                                             comp_view.invoke(std::move(f));
+                                         });
                     });
             });
     }

--- a/include/matter/util/algorithm.hpp
+++ b/include/matter/util/algorithm.hpp
@@ -8,8 +8,45 @@
 #include <iterator>
 #include <utility>
 
+#include "matter/util/iterator.hpp"
+#include "matter/util/traits.hpp"
+
 namespace matter
 {
+
+template<typename T, typename U = T>
+struct less
+{
+    constexpr less() noexcept = default;
+
+    constexpr bool operator()(const T& lhs, const U& rhs) const
+    {
+        return lhs < rhs;
+    }
+};
+
+template<typename T, typename U = T>
+struct greater
+{
+    constexpr greater() noexcept = default;
+
+    constexpr bool operator()(const T& lhs, const U& rhs) const
+    {
+        return lhs > rhs;
+    }
+};
+
+template<typename ForwardIt, typename Sentinel, typename UnaryFunction>
+constexpr void
+for_each(ForwardIt first, Sentinel last, UnaryFunction f) noexcept(
+    std::is_nothrow_invocable_v<UnaryFunction, typename ForwardIt::reference>)
+{
+    for (; last != first; ++first)
+    {
+        f(*first);
+    }
+}
+
 namespace detail
 {
 // used to have constexpr property until c++20
@@ -100,19 +137,38 @@ rotate(ForwardIt first, ForwardIt n_first, ForwardIt last) noexcept
     return write;
 }
 
-template<typename ForwardIt, typename T, typename Compare = std::less<T>>
+template<typename Iterator, typename Sentinel>
+constexpr auto distance(Iterator first, Sentinel last) noexcept
+{
+    if constexpr (matter::is_sized_v<Iterator, Sentinel>)
+    {
+        return last - first;
+    }
+    else
+    {
+        auto dist = 0;
+        while (first != last)
+        {
+            ++first;
+            ++dist;
+        }
+
+        return dist;
+    }
+}
+
+template<typename ForwardIt,
+         typename Sentinel,
+         typename T,
+         typename Compare = std::less<T>>
 constexpr ForwardIt upper_bound(ForwardIt first,
-                                ForwardIt last,
+                                Sentinel  last,
                                 const T&  value,
                                 Compare   comp = std::less<T>{}) noexcept
 {
-    ForwardIt                                                 it = first;
-    typename std::iterator_traits<ForwardIt>::difference_type count =
-                                                                  std::distance(
-                                                                      first,
-                                                                      last),
-                                                              step = count / 2;
-    count = std::distance(first, last);
+    auto it    = first;
+    auto count = matter::distance(first, last);
+    auto step  = count / 2;
 
     while (count > 0)
     {
@@ -120,6 +176,38 @@ constexpr ForwardIt upper_bound(ForwardIt first,
         step = count / 2;
         std::advance(it, step);
         if (!comp(value, *it))
+        {
+            first = ++it;
+            count -= step + 1;
+        }
+        else
+        {
+            count = step;
+        }
+    }
+
+    return first;
+}
+
+template<typename ForwardIt,
+         typename Sentinel,
+         typename T,
+         typename Compare = std::less<T>>
+constexpr ForwardIt lower_bound(ForwardIt first,
+                                Sentinel  last,
+                                const T&  value,
+                                Compare   comp = std::less<T>{}) noexcept
+{
+    ForwardIt it;
+    auto      count = matter::distance(first, last);
+    auto      step  = count / 2;
+
+    while (count > 0)
+    {
+        it   = first;
+        step = count / 2;
+        std::advance(it, step);
+        if (comp(*it, value))
         {
             first = ++it;
             count -= step + 1;

--- a/include/matter/util/algorithm.hpp
+++ b/include/matter/util/algorithm.hpp
@@ -160,11 +160,14 @@ constexpr auto distance(Iterator first, Sentinel last) noexcept
 template<typename ForwardIt,
          typename Sentinel,
          typename T,
-         typename Compare = std::less<T>>
-constexpr ForwardIt upper_bound(ForwardIt first,
-                                Sentinel  last,
-                                const T&  value,
-                                Compare   comp = std::less<T>{}) noexcept
+         typename Compare =
+             matter::less<T, std::decay_t<matter::iter_reference_t<ForwardIt>>>>
+constexpr ForwardIt upper_bound(
+    ForwardIt first,
+    Sentinel  last,
+    const T&  value,
+    Compare   comp = matter::
+        less<T, std::decay_t<matter::iter_reference_t<ForwardIt>>>{}) noexcept
 {
     auto it    = first;
     auto count = matter::distance(first, last);
@@ -192,20 +195,20 @@ constexpr ForwardIt upper_bound(ForwardIt first,
 template<typename ForwardIt,
          typename Sentinel,
          typename T,
-         typename Compare = std::less<T>>
+         typename Compare =
+             matter::less<std::decay_t<matter::iter_reference_t<ForwardIt>>, T>>
 constexpr ForwardIt lower_bound(ForwardIt first,
                                 Sentinel  last,
                                 const T&  value,
-                                Compare   comp = std::less<T>{}) noexcept
+                                Compare   comp = Compare{}) noexcept
 {
-    ForwardIt it;
-    auto      count = matter::distance(first, last);
-    auto      step  = count / 2;
+    auto count = matter::distance(first, last);
+    auto step  = count / 2;
 
     while (count > 0)
     {
-        it   = first;
-        step = count / 2;
+        auto it = first;
+        step    = count / 2;
         std::advance(it, step);
         if (comp(*it, value))
         {
@@ -221,8 +224,8 @@ constexpr ForwardIt lower_bound(ForwardIt first,
     return first;
 }
 
-template<typename ForwardIt>
-constexpr void insertion_sort(ForwardIt begin, ForwardIt last) noexcept
+template<typename ForwardIt, typename Sentinel>
+constexpr void insertion_sort(ForwardIt begin, Sentinel last) noexcept
 {
     for (auto it = begin; it != last; ++it)
     {

--- a/include/matter/util/iterator.hpp
+++ b/include/matter/util/iterator.hpp
@@ -30,6 +30,9 @@ using reverse_sentinel_t = decltype(std::declval<T>().rend());
 
 template<typename T>
 using const_reverse_sentinel_t = decltype(std::declval<T>().crend());
+
+template<typename Iter>
+using iter_reference_t = decltype(*std::declval<Iter>());
 } // namespace matter
 
 #endif

--- a/include/matter/util/iterator.hpp
+++ b/include/matter/util/iterator.hpp
@@ -1,0 +1,35 @@
+#ifndef MATTER_UTIL_ITERATOR_HPP
+#define MATTER_UTIL_ITERATOR_HPP
+
+#pragma once
+
+#include <utility>
+
+namespace matter
+{
+template<typename T>
+using iterator_t = decltype(std::declval<T>().begin());
+
+template<typename T>
+using const_iterator_t = decltype(std::declval<T>().cbegin());
+
+template<typename T>
+using reverse_iterator_t = decltype(std::declval<T>().rbegin());
+
+template<typename T>
+using const_reverse_iterator_t = decltype(std::declval<T>().crbegin());
+
+template<typename T>
+using sentinel_t = decltype(std::declval<T>().end());
+
+template<typename T>
+using const_sentinel_t = decltype(std::declval<T>().cend());
+
+template<typename T>
+using reverse_sentinel_t = decltype(std::declval<T>().rend());
+
+template<typename T>
+using const_reverse_sentinel_t = decltype(std::declval<T>().crend());
+} // namespace matter
+
+#endif

--- a/include/matter/util/traits.hpp
+++ b/include/matter/util/traits.hpp
@@ -1,0 +1,53 @@
+#ifndef MATTER_UTIL_TRAITS_HPP
+#define MATTER_UTIL_TRAITS_HPP
+
+#pragma once
+
+#include <type_traits>
+
+namespace matter
+{
+namespace impl
+{
+template<typename... Ts>
+struct smallest_;
+
+template<typename T, typename... Ts>
+struct smallest_<T, Ts...>
+{
+    using type = T;
+};
+
+template<typename T, typename U, typename... Ts>
+struct smallest_<T, U, Ts...>
+{
+    using type = std::conditional_t<(sizeof(U) < sizeof(T)), U, T>;
+};
+} // namespace impl
+
+/// \brief holds the smallest of the passed types in ::type
+/// if 2 types are the same size the first is picked by default
+template<typename... Ts>
+struct smallest : impl::smallest_<Ts...>
+{};
+
+template<typename... Ts>
+using smallest_t = typename smallest<Ts...>::type;
+
+template<typename T, typename U, typename = void>
+struct is_sized : std::false_type
+{};
+
+template<typename T, typename U>
+struct is_sized<
+    T,
+    U,
+    std::void_t<decltype(std::declval<const T>() - std::declval<const U>())>>
+    : std::true_type
+{};
+
+template<typename T, typename U>
+constexpr auto is_sized_v = is_sized<T, U>::value;
+} // namespace matter
+
+#endif

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -37,6 +37,10 @@ TEST_CASE("group_vector")
         {
             SECTION("group_vector size 1")
             {
+                auto start = grpvec1.begin();
+                auto end   = grpvec1.end();
+                CHECK((end - start) == 4);
+
                 // all the emplaced stores should be correctly sorted now
                 auto it = grpvec1.begin();
                 CHECK((*it).contains(ident.id<int>()));
@@ -52,6 +56,11 @@ TEST_CASE("group_vector")
 
             SECTION("group_vector size 2")
             {
+                // check for sizedrange
+                auto start = grpvec2.begin();
+                auto end   = grpvec2.end();
+                CHECK((end - start) == 2);
+
                 auto                    it  = grpvec2.begin();
                 matter::const_any_group grp = *it;
                 CHECK(grp == ident.ordered_ids<float, int>());
@@ -64,6 +73,10 @@ TEST_CASE("group_vector")
 
             SECTION("group_vector size 3")
             {
+                auto start = grpvec3.begin();
+                auto end   = grpvec3.end();
+                CHECK((end - start) == 3);
+
                 auto                    it = grpvec3.begin();
                 matter::const_any_group grp{*it};
                 CHECK(grp == ident.ordered_ids<int, float, short>());
@@ -99,6 +112,11 @@ TEST_CASE("group_vector")
         {
             SECTION("group_vector size 1")
             {
+                auto start = grpvec1.rbegin();
+                auto end   = grpvec1.rend();
+                CHECK((end - start) == 4);
+                CHECK(grpvec1.size() == 4);
+
                 auto rit = grpvec1.rbegin();
                 CHECK((*rit).contains(ident.id<char>()));
                 ++rit;
@@ -113,6 +131,11 @@ TEST_CASE("group_vector")
 
             SECTION("group_vector size 2")
             {
+                auto start = grpvec2.rbegin();
+                auto end   = grpvec2.rend();
+                CHECK((end - start) == 2);
+                CHECK(grpvec2.size() == 2);
+
                 auto                    it = grpvec2.rbegin();
                 matter::const_any_group grp{*it};
                 CHECK(grp == ident.ordered_ids<short, char>());
@@ -125,6 +148,11 @@ TEST_CASE("group_vector")
 
             SECTION("group_vector size 3")
             {
+                auto start = grpvec3.rbegin();
+                auto end   = grpvec3.rend();
+                CHECK((end - start) == 3);
+                CHECK(grpvec3.size() == 3);
+
                 auto                    it = grpvec3.rbegin();
                 matter::const_any_group grp{*it};
                 CHECK(grp == ident.ordered_ids<float, short, char>());
@@ -171,6 +199,7 @@ TEST_CASE("group_vector")
                 ++it;
                 find_grp_it =
                     grpvec3.find(ident.ordered_ids<short, char, float>());
+                CHECK(it != grp_view.end());
 
                 // CHECK(*find_grp_it == *it);
 
@@ -182,20 +211,12 @@ TEST_CASE("group_vector")
             {
                 auto grp_view =
                     matter::group_vector_view{ident.ids<int>(), grpvec3};
-                auto find_grp_it =
-                    grpvec3.find(ident.ordered_ids<int, short, char>());
-                CHECK(find_grp_it != grpvec3.end());
-                auto view_it = grp_view.rbegin();
+                auto view_it = grp_view.rbegin(); // int, short, char
 
-                // CHECK(*find_grp_it == *view_it);
+                ++view_it; // float, int, short
+                CHECK(view_it != grp_view.rend());
 
-                ++view_it;
-                find_grp_it =
-                    grpvec3.find(ident.ordered_ids<int, float, short>());
-
-                // CHECK(*find_grp_it == *view_it);
-
-                ++view_it;
+                ++view_it; // 1 past the end
                 CHECK(view_it == grp_view.rend());
             }
         }

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -222,7 +222,7 @@ TEST_CASE("group_vector")
             auto view = matter::group_view{grp};
 
             auto i = 0;
-            std::for_each(view.begin(), view.end(), [&](auto comp_view) {
+            matter::for_each(view.begin(), view.end(), [&](auto comp_view) {
                 auto [fcomp, icomp, scomp] = comp_view;
                 CHECK(fcomp == i);
                 CHECK(icomp == i);


### PR DESCRIPTION
fixes #68 

Because of the use of fairly heavy iterators, especially in the case of `group_vector_view`. This allows the returned `end()` to contain and empty sentinel. Basically overall an optimization to save on space for the past the end sentinel.