### PR TITLE
Implement iterator for registry_view

### DIFF
--- a/include/matter/component/group_vector_view.hpp
+++ b/include/matter/component/group_vector_view.hpp
@@ -41,13 +41,16 @@ public:
 
     private:
         group_vector_iterator_type it_;
-        typed_ids_type             ids_;
-        ordered_ids_type           ordered_ids_;
+
+        typed_ids_type   ids_;
+        ordered_ids_type ordered_ids_;
 
         group_vector_base_iterator_type begin_;
         group_vector_sentinel_type      end_;
 
     public:
+        constexpr iterator() = default;
+
         constexpr iterator(const typed_ids_type&      ids,
                            const ordered_ids_type&    ordered_ids,
                            group_vector_iterator_type it,

--- a/include/matter/component/group_vector_view.hpp
+++ b/include/matter/component/group_vector_view.hpp
@@ -397,7 +397,7 @@ public:
         : ids_{ids}, ordered_ids_{matter::ordered_typed_ids{ids_}},
           group_vec_{group_vec}
     {
-        assert(typed_ids_type::size() <= group_vec.group_size());
+        assert(ids.size() <= group_vec.group_size());
     }
 
     constexpr iterator begin() noexcept

--- a/include/matter/component/group_view.hpp
+++ b/include/matter/component/group_view.hpp
@@ -34,6 +34,8 @@ public:
         std::tuple<storage_iterator_type<Cs>...> its_;
 
     public:
+        constexpr iterator() = default;
+
         constexpr iterator(storage_iterator_type<Cs>... its) noexcept
             : its_{its...}
         {}
@@ -145,8 +147,7 @@ public:
         storage_sentinel_type<detail::nth_t<0, Cs...>> sent_;
 
     public:
-        sentinel() noexcept : sent_{}
-        {}
+        sentinel() noexcept = default;
 
         sentinel(storage_sentinel_type<Cs>... sents) noexcept
             : sent_{std::get<0>(std::make_tuple(sents...))}

--- a/include/matter/component/registry_view.hpp
+++ b/include/matter/component/registry_view.hpp
@@ -21,51 +21,230 @@ struct registry_view<matter::unordered_typed_ids<Id, TIds...>>
     using id_type            = Id;
     using unordered_ids_type = matter::unordered_typed_ids<id_type, TIds...>;
 
+    struct iterator
+    {
+        using group_vector_container_type = std::vector<group_vector>;
+        using group_vector_container_iterator_type =
+            matter::iterator_t<group_vector_container_type>;
+        using group_vector_container_sentinel_type =
+            matter::sentinel_t<group_vector_container_type>;
+
+        using group_vector_view_type = decltype(matter::group_vector_view{
+            std::declval<unordered_ids_type>(),
+            *std::declval<group_vector_container_iterator_type>()});
+        using group_vector_view_iterator_type =
+            matter::iterator_t<group_vector_view_type>;
+        using group_vector_view_sentinel_type =
+            matter::sentinel_t<group_vector_view_type>;
+
+        using group_view_type = matter::group_view<typename TIds::type...>;
+        using group_view_iterator_type = matter::iterator_t<group_view_type>;
+        using group_view_sentinel_type = matter::sentinel_t<group_view_type>;
+
+        using value_type = matter::component_view<typename TIds::type...>;
+        using reference  = value_type;
+        using pointer    = void;
+        using iterator_category = std::forward_iterator_tag;
+        using difference_type   = typename std::iterator_traits<
+            matter::iterator_t<group_view_type>>::difference_type;
+
+    private:
+        unordered_ids_type ids_;
+
+        group_vector_container_iterator_type grp_vec_container_it_;
+        group_vector_container_sentinel_type grp_vec_container_sent_;
+
+        group_vector_view_iterator_type grp_vec_view_it_;
+        group_vector_view_sentinel_type grp_vec_view_sent_;
+
+        group_view_iterator_type grp_view_it_;
+        group_view_sentinel_type grp_view_sent_;
+
+    public:
+        constexpr iterator(
+            const unordered_ids_type&            ids,
+            group_vector_container_iterator_type begin_range,
+            group_vector_container_sentinel_type end_range) noexcept
+            : ids_{ids}, grp_vec_container_it_{begin_range + std::size(ids)},
+              grp_vec_container_sent_{end_range}, grp_vec_view_it_{},
+              grp_vec_view_sent_{}, grp_view_it_{}, grp_view_sent_{}
+        {
+            grp_vec_container_it_   = begin_range + std::size(ids);
+            grp_vec_container_sent_ = end_range;
+
+            for (; grp_vec_container_it_ < grp_vec_container_sent_;
+                 ++grp_vec_container_it_)
+            {
+                auto grp_vec_view =
+                    group_vector_view_type{ids_, *grp_vec_container_it_};
+
+                grp_vec_view_it_   = grp_vec_view.begin();
+                grp_vec_view_sent_ = grp_vec_view.end();
+                for (; grp_vec_view_it_ != grp_vec_view_sent_;
+                     ++grp_vec_view_it_)
+                {
+                    auto grp_view = *grp_vec_view_it_;
+
+                    grp_view_it_   = grp_view.begin();
+                    grp_view_sent_ = grp_view.end();
+                    for (; grp_view_it_ != grp_view_sent_; ++grp_view_it_)
+                    {
+                        // simply iterate until we get to our first valid
+                        // component_view, return afterwards as we're now in a
+                        // valid state
+                        return;
+                    }
+                }
+            }
+        }
+
+        constexpr iterator& operator++() noexcept
+        {
+            // if we hit the end of our current group
+            // we need to find our next group to view
+            if (++grp_view_it_ == grp_view_sent_)
+            {
+                do
+                {
+                    // if our current group_vector is at the end of valid groups
+                    // of this size we need to go to the next group_vector
+                    if (++grp_vec_view_it_ == grp_vec_view_sent_)
+                    {
+                        do
+                        {
+                            // if our next container iterator is larger than the
+                            // sentinel it means we've exhausted our group
+                            // vectors and are now officialy in the end state
+                            if (++grp_vec_container_it_ ==
+                                grp_vec_container_sent_)
+                            {
+                                // end state, do nothing
+                                return *this;
+                            }
+                            else
+                            {
+                                auto grp_vec_view = group_vector_view_type{
+                                    ids_, *grp_vec_container_it_};
+                                grp_vec_view_it_   = grp_vec_view.begin();
+                                grp_vec_view_sent_ = grp_vec_view.end();
+                            }
+                            // keep incrementing if there are no valid groups of
+                            // the specified size found
+                        } while (grp_vec_view_it_ == grp_vec_view_sent_);
+                    }
+                    else
+                    {
+                        auto grp_view  = *grp_vec_view_it_;
+                        grp_view_it_   = grp_view.begin();
+                        grp_view_sent_ = grp_view.end();
+                    }
+
+                    // skip over any empty groups
+                } while (grp_view_it_ == grp_view_sent_);
+            }
+
+            return *this;
+        }
+
+        constexpr iterator operator++(int) noexcept
+        {
+            auto it = *this;
+            ++(*this);
+            return it;
+        }
+
+        constexpr reference operator*() const noexcept
+        {
+            return *grp_view_it_;
+        }
+
+        constexpr auto is_beyond_end() const noexcept
+        {
+            return grp_vec_container_it_ >= grp_vec_container_sent_;
+        }
+    };
+
+    struct sentinel
+    {
+        constexpr sentinel() noexcept = default;
+
+        constexpr auto operator==(const iterator& it) const noexcept
+        {
+            return it.is_beyond_end();
+        }
+
+        constexpr auto operator!=(const iterator& it) const noexcept
+        {
+            return !(*this == it);
+        }
+
+        constexpr friend auto operator==(const iterator& it,
+                                         const sentinel&) noexcept
+        {
+            return it.is_beyond_end();
+        }
+
+        constexpr friend auto operator!=(const iterator& it,
+                                         const sentinel& sent) noexcept
+        {
+            return !(sent == it);
+        }
+    };
+
 private:
-    matter::unordered_typed_ids<id_type, TIds...> ids_;
-    std::vector<group_vector>::iterator           begin_;
-    std::vector<group_vector>::iterator           end_;
+    unordered_ids_type                            ids_;
+    matter::iterator_t<std::vector<group_vector>> begin_;
+    matter::sentinel_t<std::vector<group_vector>> end_;
 
 public:
-    constexpr registry_view(const unordered_ids_type&           ids,
-                            std::vector<group_vector>::iterator begin,
-                            std::vector<group_vector>::iterator end) noexcept
-        : ids_{ids}, begin_{begin + unordered_ids_type::size()}, end_{end}
+    constexpr registry_view(
+        const unordered_ids_type&                     ids,
+        matter::iterator_t<std::vector<group_vector>> begin,
+        matter::sentinel_t<std::vector<group_vector>> end) noexcept
+        : ids_{ids}, begin_{begin}, end_{end}
     {}
 
-    template<typename Function>
-    void for_each(Function f) noexcept(
-        std::is_nothrow_invocable_v<Function, typename TIds::type&...>)
+    constexpr iterator begin() noexcept
     {
-        if (begin_ >= end_)
+        return iterator{ids_, begin_, end_};
+    }
+
+    constexpr sentinel end() const noexcept
+    {
+        return sentinel{};
+    }
+
+    template<typename Function>
+    void for_each(Function f) const
+        noexcept(std::is_nothrow_invocable_v<Function, typename TIds::type&...>)
+    {
+        auto it = begin_ + ids_.size();
+        if (it >= end_)
         {
             return;
         }
 
         matter::for_each(
-            begin_,
-            end_,
-            [ids = ids_, f = std::move(f)](group_vector& grp_vec) {
+            it, end_, [ids = ids_, f = std::move(f)](group_vector& grp_vec) {
                 matter::group_vector_view view{ids, grp_vec};
-                matter::for_each(
-                    view.begin(),
-                    view.end(),
-                    [f = std::move(f), size = grp_vec.group_size(), ids](
-                        auto grp_view) {
-                        matter::for_each(grp_view.begin(),
+                matter::for_each(view.begin(),
+                                 view.end(),
+                                 [f = std::move(f)](auto grp_view) {
+                                     matter::for_each(
+                                         grp_view.begin(),
                                          grp_view.end(),
                                          [f = std::move(f)](auto comp_view) {
                                              comp_view.invoke(std::move(f));
                                          });
-                    });
+                                 });
             });
     }
 };
 
 template<typename Id, typename... TIds>
 registry_view(const matter::unordered_typed_ids<Id, TIds...>,
-              std::vector<group_vector>::iterator begin,
-              std::vector<group_vector>::iterator end)
+              matter::iterator_t<std::vector<group_vector>> begin,
+              matter::sentinel_t<std::vector<group_vector>> end)
     ->registry_view<matter::unordered_typed_ids<Id, TIds...>>;
 } // namespace matter
 

--- a/include/matter/util/algorithm.hpp
+++ b/include/matter/util/algorithm.hpp
@@ -37,7 +37,7 @@ struct greater
 };
 
 template<typename ForwardIt, typename Sentinel, typename UnaryFunction>
-constexpr void
+constexpr UnaryFunction
 for_each(ForwardIt first, Sentinel last, UnaryFunction f) noexcept(
     std::is_nothrow_invocable_v<UnaryFunction, typename ForwardIt::reference>)
 {
@@ -45,6 +45,8 @@ for_each(ForwardIt first, Sentinel last, UnaryFunction f) noexcept(
     {
         f(*first);
     }
+
+    return f;
 }
 
 namespace detail
@@ -60,12 +62,12 @@ constexpr void swap_if_less(T& lhs, T& rhs) noexcept
 } // namespace detail
 
 // simply a is_sorted that is constexpr until c++20 has it
-template<typename ForwardIt>
-constexpr bool is_sorted(ForwardIt first, ForwardIt last) noexcept
+template<typename ForwardIt, typename Sentinel>
+constexpr bool is_sorted(ForwardIt first, Sentinel last) noexcept
 {
     if (first != last)
     {
-        ForwardIt next = first;
+        ForwardIt next{first};
         while (++next != last)
         {
             if (*next < *first)

--- a/test/test_entt.cpp
+++ b/test/test_entt.cpp
@@ -99,6 +99,30 @@ TEST_CASE("benchmarks")
 
             pos_view.for_each([](position& pos) { pos.x = {}; });
         }
+
+        SECTION("iterator const")
+        {
+            timer t{
+                "Iterating over 1000000 single components - const iterator"};
+
+            auto pos_view = reg.view<position>();
+
+            matter::for_each(
+                pos_view.begin(), pos_view.end(), [](const auto&) {});
+        }
+
+        SECTION("iterator mut")
+        {
+            timer t{"Iterating over 1000000 single components - mut iterator"};
+
+            auto pos_view = reg.view<position>();
+
+            matter::for_each(
+                pos_view.begin(), pos_view.end(), [](auto&& comp_view) {
+                    comp_view.invoke(
+                        [](position& position) { position.x = {}; });
+                });
+        }
     }
     // TODO: test destroying
 
@@ -158,7 +182,7 @@ TEST_CASE("benchmarks")
         SECTION("mutable")
         {
             timer t{"Iterating over 1000000 double components, only half "
-                    "double - const"};
+                    "double - mut"};
 
             auto view = reg.view<position, velocity>();
 

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -18,6 +18,30 @@ TEST_CASE("group_vector")
     CHECK(grpvec2.group_size() == 2);
     CHECK(grpvec3.group_size() == 3);
 
+    SECTION("default iterators")
+    {
+        SECTION("group_view")
+        {
+            // default constructed iterator and sentinel should both be equal
+            matter::group_view<int>::iterator it{};
+            matter::group_view<int>::sentinel sent{};
+
+            CHECK(it == sent);
+        }
+
+        SECTION("group_vector_view")
+        {
+            using group_vector_view_type = decltype(matter::group_vector_view{
+                ident.ids<int, float>(),
+                std::declval<matter::group_vector&>()});
+
+            group_vector_view_type::iterator it{};
+            group_vector_view_type::sentinel sent{};
+
+            CHECK(it == sent);
+        }
+    }
+
     SECTION("emplace storage")
     {
 
@@ -32,6 +56,67 @@ TEST_CASE("group_vector")
         grpvec3.emplace(ident.ids<short, char, float>()); // 1 2 3 -> 3rd
         grpvec3.emplace(ident.ids<int, short, char>());   // 0 2 3 -> 2nd
         grpvec3.emplace(ident.ids<float, int, short>());  // 0 1 3 -> 1st
+
+        SECTION("check empty views")
+        {
+            ident.register_type<uint64_t>();
+            SECTION("size 1")
+            {
+                auto view =
+                    matter::group_vector_view{ident.ids<uint64_t>(), grpvec1};
+
+                auto it  = view.begin();
+                auto end = view.end();
+
+                CHECK(it == end);
+
+                SECTION("reverse")
+                {
+                    auto rit  = view.rbegin();
+                    auto rend = view.rend();
+
+                    CHECK(rit == rend);
+                }
+            }
+
+            SECTION("size 2")
+            {
+                SECTION("wrong size")
+                {
+                    auto view = matter::group_vector_view{ident.ids<uint64_t>(),
+                                                          grpvec2};
+
+                    auto it  = view.begin();
+                    auto end = view.end();
+
+                    CHECK(it == end);
+
+                    SECTION("reverse")
+                    {
+                        auto rit  = view.rbegin();
+                        auto rend = view.rend();
+
+                        CHECK(rit == rend);
+                    }
+                }
+
+                auto view = matter::group_vector_view{
+                    ident.ids<uint64_t, float>(), grpvec2};
+
+                auto it  = view.begin();
+                auto end = view.end();
+
+                CHECK(it == end);
+
+                SECTION("reverse")
+                {
+                    auto rit  = view.rbegin();
+                    auto rend = view.rend();
+
+                    CHECK(rit == rend);
+                }
+            }
+        }
 
         SECTION("sorted")
         {

--- a/test/test_registry.cpp
+++ b/test/test_registry.cpp
@@ -128,6 +128,38 @@ TEST_CASE("registry")
                     CHECK(fcomp.f == j);
                     ++j;
                 });
+
+                SECTION("iterator")
+                {
+                    SECTION("empty iterator validation")
+                    {
+                        matter::registry<int, float, char> empty_reg;
+                        empty_reg.create<float>(std::forward_as_tuple(5.0f));
+
+                        auto empty_view  = empty_reg.view<int>();
+                        auto empty_begin = empty_view.begin();
+                        auto empty_end   = empty_view.end();
+                        // check if empty init is valid
+                        CHECK(empty_begin == empty_end);
+                    }
+                    // auto sent = fview.end();
+                    auto j1 = 0;
+                    matter::for_each(
+                        fview.begin(), fview.end(), [&](auto&& comp_view) {
+                            comp_view.invoke([&](float_comp& fcomp) {
+                                CHECK(fcomp.f == j1);
+                                fcomp.f = (2 * j1);
+                                ++j1;
+                            });
+                        });
+                    j1 = 0;
+                    matter::for_each(
+                        fview.begin(), fview.end(), [&](auto&& comp_view) {
+                            auto [fcomp] = comp_view;
+                            CHECK(fcomp.f == (2 * j1));
+                            ++j1;
+                        });
+                }
             }
 
             std::vector<float_comp> fvec2;


### PR DESCRIPTION
This is a basic iterator for `registry_view` that can be used with `matter::for_each` instead of using `registry_view::for_each`. But sadly even though functionally equivalent this is currently slower.

Rethinking the usage of iterators might be necessary and favor using indices for component storage at least.