### PR TITLE
insert_buffer to guarantee the insertion contract

### DIFF
--- a/include/matter/component/group_vector.hpp
+++ b/include/matter/component/group_vector.hpp
@@ -31,6 +31,8 @@ public:
     {
         using vector_iterator_type =
             matter::iterator_t<std::vector<matter::erased_storage>>;
+        using group_size_iterator_type =
+            matter::iterator_t<std::vector<std::size_t>>;
 
         using value_type        = any_group;
         using reference         = value_type;
@@ -41,14 +43,18 @@ public:
             vector_iterator_type>::difference_type;
 
     private:
-        vector_iterator_type it_;
-        std::size_t          size_;
+        vector_iterator_type     it_;
+        group_size_iterator_type size_it_;
+
+        std::size_t group_size_;
 
     public:
         iterator() noexcept = default;
 
-        constexpr iterator(vector_iterator_type it, std::size_t size) noexcept
-            : it_{it}, size_{size}
+        constexpr iterator(vector_iterator_type     it,
+                           group_size_iterator_type size_it,
+                           std::size_t              group_size) noexcept
+            : it_{it}, size_it_{size_it}, group_size_{group_size}
         {}
 
         auto base() const noexcept
@@ -58,7 +64,7 @@ public:
 
         auto group_size() const noexcept
         {
-            return size_;
+            return group_size_;
         }
 
         bool operator==(const iterator& other) const noexcept
@@ -85,13 +91,15 @@ public:
 
         iterator& operator++() noexcept
         {
-            it_ += size_;
+            it_ += group_size();
+            ++size_it_;
             return *this;
         }
 
         iterator& operator--() noexcept
         {
-            it_ -= size_;
+            it_ -= group_size();
+            --size_it_;
             return *this;
         }
 
@@ -111,13 +119,15 @@ public:
 
         iterator& operator+=(difference_type movement) noexcept
         {
-            it_ += (movement * size_);
+            it_ += (movement * group_size());
+            size_it_ += movement;
             return *this;
         }
 
         iterator& operator-=(difference_type movement) noexcept
         {
-            it_ -= (movement * size_);
+            it_ -= (movement * group_size());
+            size_it_ -= movement;
             return *this;
         }
 
@@ -137,14 +147,14 @@ public:
 
         difference_type operator-(const iterator& other) const noexcept
         {
-            assert(size_ == other.size_);
-            assert((it_ - other.it_) % size_ == 0);
-            return (it_ - other.it_) / size_;
+            assert(group_size() == other.group_size());
+            assert((it_ - other.it_) % group_size() == 0);
+            return size_it_ - other.size_it_;
         }
 
         reference operator*() const noexcept
         {
-            return {*it_, size_};
+            return {*it_, *size_it_, group_size()};
         }
     };
 
@@ -152,6 +162,8 @@ public:
     {
         using vector_const_iterator_type =
             matter::const_iterator_t<std::vector<matter::erased_storage>>;
+        using group_size_const_iterator_type =
+            matter::const_iterator_t<std::vector<std::size_t>>;
 
         using value_type        = const_any_group;
         using reference         = value_type;
@@ -162,15 +174,17 @@ public:
             vector_const_iterator_type>::difference_type;
 
     private:
-        vector_const_iterator_type it_;
-        std::size_t                size_;
+        vector_const_iterator_type     it_;
+        group_size_const_iterator_type size_it_;
+        std::size_t                    size_;
 
     public:
         const_iterator() noexcept = default;
 
-        constexpr const_iterator(vector_const_iterator_type it,
-                                 std::size_t                size) noexcept
-            : it_{it}, size_{size}
+        constexpr const_iterator(vector_const_iterator_type     it,
+                                 group_size_const_iterator_type size_it,
+                                 std::size_t                    size) noexcept
+            : it_{it}, size_it_{size_it}, size_{size}
         {}
 
         const_iterator(const iterator& it) noexcept
@@ -219,13 +233,15 @@ public:
 
         const_iterator& operator++() noexcept
         {
-            it_ += size_;
+            it_ += group_size();
+            ++size_it_;
             return *this;
         }
 
         const_iterator& operator--() noexcept
         {
-            it_ -= size_;
+            it_ -= group_size();
+            --size_it_;
             return *this;
         }
 
@@ -245,13 +261,15 @@ public:
 
         const_iterator& operator+=(difference_type movement) noexcept
         {
-            it_ += (movement * size_);
+            it_ += (movement * group_size());
+            size_it_ += movement;
             return *this;
         }
 
         const_iterator& operator-=(difference_type movement) noexcept
         {
-            it_ -= (movement * size_);
+            it_ -= (movement * group_size());
+            size_it_ -= movement;
             return *this;
         }
 
@@ -273,12 +291,12 @@ public:
         {
             assert(group_size() == other.group_size());
             assert((base() - other.base()) % group_size() == 0);
-            return (base() - other.base()) / group_size();
+            return (size_it_ - other.size_it_);
         }
 
         reference operator*() const noexcept
         {
-            return {*it_, size_};
+            return {*it_, *size_it_, size_};
         }
     };
 
@@ -286,6 +304,8 @@ public:
     {
         using vector_reverse_iterator_type =
             matter::reverse_iterator_t<std::vector<matter::erased_storage>>;
+        using group_size_reverse_iterator_type =
+            matter::reverse_iterator_t<std::vector<std::size_t>>;
 
         using value_type        = any_group;
         using reference         = value_type;
@@ -296,15 +316,17 @@ public:
             vector_reverse_iterator_type>::difference_type;
 
     private:
-        vector_reverse_iterator_type it_;
-        std::size_t                  size_;
+        vector_reverse_iterator_type     it_;
+        group_size_reverse_iterator_type size_it_;
+        std::size_t                      size_;
 
     public:
         reverse_iterator() = default;
 
-        constexpr reverse_iterator(vector_reverse_iterator_type it,
-                                   std::size_t                  size) noexcept
-            : it_{it}, size_{size}
+        constexpr reverse_iterator(vector_reverse_iterator_type     it,
+                                   group_size_reverse_iterator_type size_it,
+                                   std::size_t size) noexcept
+            : it_{it}, size_it_{size_it}, size_{size}
         {}
 
         auto base() const noexcept
@@ -387,7 +409,7 @@ public:
 
         reference operator*() const noexcept
         {
-            return {*it_, size_};
+            return {*it_, *size_it_, size_};
         }
     };
 
@@ -396,6 +418,8 @@ public:
         using vector_const_reverse_iterator_type =
             matter::const_reverse_iterator_t<
                 std::vector<matter::erased_storage>>;
+        using group_size_const_reverse_iterator_type =
+            matter::const_reverse_iterator_t<std::vector<std::size_t>>;
 
         using value_type        = const_any_group;
         using reference         = value_type;
@@ -406,8 +430,9 @@ public:
             vector_const_reverse_iterator_type>::difference_type;
 
     private:
-        vector_const_reverse_iterator_type it_;
-        std::size_t                        size_;
+        vector_const_reverse_iterator_type     it_;
+        group_size_const_reverse_iterator_type size_it_;
+        std::size_t                            size_;
 
     public:
         const_reverse_iterator() = default;
@@ -526,7 +551,7 @@ public:
 
         reference operator*() const noexcept
         {
-            return {*it_, size_};
+            return {*it_, *size_it_, size_};
         }
     };
 
@@ -635,7 +660,10 @@ public:
 
 private:
     /// the number of components each group stores
-    const std::size_t                   size_;
+    const std::size_t size_;
+    /// contains the sizes of the groups, to not rely on the stores implementing
+    /// size()
+    std::vector<std::size_t>            group_sizes_{};
     std::vector<matter::erased_storage> groups_{};
 
 public:
@@ -644,12 +672,12 @@ public:
 
     iterator begin() noexcept
     {
-        return {groups_.begin(), group_size()};
+        return {groups_.begin(), group_sizes_.begin(), group_size()};
     }
 
     const_iterator begin() const noexcept
     {
-        return {groups_.begin(), group_size()};
+        return {groups_.begin(), group_sizes_.begin(), group_size()};
     }
 
     auto end() const noexcept
@@ -659,12 +687,16 @@ public:
 
     reverse_iterator rbegin() noexcept
     {
+        // this arithmetic is necessary to properly align the offsets
         return reverse_iterator{groups_.rbegin() + (group_size() - 1),
+                                group_sizes_.rbegin(),
                                 group_size()};
     }
 
     auto rend() const noexcept
     {
+        // make sure we correct the offset to that --~aaabbbccc becomes
+        // ~--aaabbbccc, look for tilde (~)
         return reverse_sentinel{groups_.crend() + (group_size() - 1)};
     }
 
@@ -710,7 +742,10 @@ public:
         }
 
         auto grp = *it;
-        return grp == ids ? it : const_iterator{groups_.end(), group_size()};
+        return grp == ids ? it :
+                            const_iterator{groups_.end(),
+                                           group_sizes_.end(),
+                                           group_size()};
     }
 
     /// \brief finds an exact match for the ids, otherwise end()
@@ -731,7 +766,9 @@ public:
         }
 
         auto grp = *it;
-        return grp == ids ? it : iterator{groups_.end(), group_size()};
+        return grp == ids ?
+                   it :
+                   iterator{groups_.end(), group_sizes_.end(), group_size()};
     }
 
     template<typename... TIds>
@@ -810,13 +847,13 @@ public:
     any_group operator[](std::size_t index) noexcept
     {
         assert(index <= size());
-        return any_group{std::addressof(groups_[size_ * index]), size_};
+        return any_group{
+            std::addressof(groups_[size_ * index]), group_sizes_[index], size_};
     }
 
     std::size_t size() const noexcept
     {
-        assert((groups_.size() % size_) == 0);
-        return groups_.size() / size_;
+        return group_sizes_.size();
     }
 
     bool empty() const noexcept
@@ -844,6 +881,8 @@ private:
             return true;
         }()));
 
+        auto distance = std::distance(begin(), pos);
+
         std::array<matter::erased_storage, sizeof...(TIds)> stores{
             matter::erased_storage{unordered_ids.template get<TIds>()}...};
 
@@ -852,8 +891,10 @@ private:
                            std::make_move_iterator(stores.begin()),
                            std::make_move_iterator(stores.end()));
 
+        auto size_it = group_sizes_.insert(group_sizes_.begin() + distance, 0);
+
         std::sort(inserted_at, inserted_at + size_);
-        return {inserted_at, group_size()};
+        return {inserted_at, size_it, group_size()};
     }
 
     template<typename... TIds>

--- a/include/matter/component/insert_buffer.hpp
+++ b/include/matter/component/insert_buffer.hpp
@@ -1,0 +1,180 @@
+#ifndef MATTER_COMPONENT_INSERT_BUFFER_HPP
+#define MATTER_COMPONENT_INSERT_BUFFER_HPP
+
+#pragma once
+
+#include <vector>
+
+#include "matter/component/typed_id.hpp"
+#include "matter/util/meta.hpp"
+
+namespace matter
+{
+template<typename UnorderedTypedIds>
+struct insert_buffer;
+
+template<typename Id, typename... TIds>
+struct insert_buffer<matter::unordered_typed_ids<Id, TIds...>>
+{
+    using id_type = Id;
+
+private:
+    template<typename UnorderedTypedIds>
+    friend struct insert_buffer;
+
+private:
+    matter::unordered_typed_ids<Id, TIds...>        ids_;
+    std::tuple<std::vector<typename TIds::type>...> buffers_;
+
+public:
+    insert_buffer(const matter::unordered_typed_ids<Id, TIds...>& ids) noexcept
+        : ids_{ids}, buffers_{}
+    {}
+
+    template<typename... UTIds>
+    insert_buffer(
+        const matter::unordered_typed_ids<Id, TIds...>& ids,
+        matter::insert_buffer<matter::unordered_typed_ids<Id, UTIds...>>&&
+            move_from) noexcept
+        : ids_{ids}, buffers_{[&]() {
+              // this will take the vector from the passed buffer and use any
+              // buffer that we also have in the current buffer
+              if constexpr (detail::type_in_list_v<typename TIds::type,
+                                                   typename UTIds::type...>)
+              {
+                  auto vec = std::vector<typename TIds::type>{
+                      std::move(move_from.template get<typename TIds::type>())};
+                  vec.clear();
+                  return vec;
+              }
+              else
+              {
+                  return std::vector<typename TIds::type>{};
+              }
+          }()...}
+    {}
+
+    template<typename T>
+    constexpr auto begin() noexcept
+    {
+        return get<T>().begin();
+    }
+
+    template<typename T>
+    constexpr auto end() noexcept
+    {
+        return get<T>().end();
+    }
+
+    template<typename T>
+    constexpr auto begin() const noexcept
+    {
+        return get<T>().begin();
+    }
+
+    template<typename T>
+    constexpr auto end() const noexcept
+    {
+        return get<T>().end();
+    }
+
+    const auto& ids() const noexcept
+    {
+        return ids_;
+    }
+
+    std::size_t size() const noexcept
+    {
+        // all buffers are guaranteed to be the same size
+        return std::get<0>(buffers_).size();
+    }
+
+    void reserve(std::size_t new_capacity) noexcept
+    {
+        return std::apply(
+            [&](auto&&... buffers) { (buffers.reserve(new_capacity), ...); },
+            buffers_);
+    }
+
+    void resize(std::size_t new_size) noexcept(
+        (std::is_nothrow_default_constructible_v<typename TIds::type> && ...))
+    {
+        return std::apply(
+            [&](auto&&... buffers) { (buffers.resize(new_size), ...); },
+            buffers_);
+    }
+
+    void resize(std::size_t new_size, const typename TIds::type... ts) noexcept(
+        (std::is_nothrow_copy_constructible_v<typename TIds::type> && ...))
+    {
+        (get<typename TIds::type>().resize(new_size, ts), ...);
+    }
+
+    template<typename... TupArgs>
+    std::enable_if_t<(
+        detail::is_constructible_expand_tuple_v<typename TIds::type, TupArgs> &&
+        ...)>
+    emplace_back(TupArgs&&... tuple_args) noexcept(
+        (detail::is_nothrow_constructible_expand_tuple_v<typename TIds::type,
+                                                         TupArgs> &&
+         ...))
+    {
+        (emplace_one_impl<typename TIds::type>(
+             std::forward<TupArgs>(tuple_args)),
+         ...);
+    }
+
+    template<typename... Args>
+    std::enable_if_t<sizeof...(Args) == sizeof...(TIds) &&
+                     (std::is_constructible_v<typename TIds::type, Args> &&
+                      ...)>
+    emplace_back(Args&&... args) noexcept(
+        (std::is_nothrow_constructible_v<typename TIds::type, Args> && ...))
+    {
+        (get<typename TIds::type>().emplace_back(std::forward<Args>(args)),
+         ...);
+    }
+
+    template<typename... Ts>
+    std::enable_if_t<sizeof...(Ts) == sizeof...(TIds) &&
+                     (std::is_constructible_v<typename TIds::type, const Ts&> &&
+                      ...)>
+    push_back(const Ts&... ts) noexcept((
+        std::is_nothrow_constructible_v<typename TIds::type, const Ts&> && ...))
+    {
+        (get<typename TIds::type>().push_back(ts), ...);
+    }
+
+private:
+    template<typename T, typename... Args>
+    void emplace_one_impl(std::tuple<Args...> tuple_args) noexcept(
+        std::is_nothrow_constructible_v<T, Args...>)
+    {
+        get<T>().emplace_back(std::get<Args>(tuple_args)...);
+    }
+
+    template<typename T>
+    auto& get() noexcept
+    {
+        return std::get<std::vector<T>>(buffers_);
+    }
+
+    template<typename T>
+    const auto& get() const noexcept
+    {
+        return std::get<std::vector<T>>(buffers_);
+    }
+};
+
+template<typename UnorderedIdsType>
+insert_buffer(
+    const UnorderedIdsType& ids) noexcept->insert_buffer<UnorderedIdsType>;
+
+template<typename UnorderedTypedIds, typename OtherUnorderedTypedIds>
+insert_buffer(const UnorderedTypedIds& ids,
+              matter::insert_buffer<OtherUnorderedTypedIds>&&
+                  move_from) noexcept->insert_buffer<UnorderedTypedIds>;
+
+} // namespace matter
+
+#endif

--- a/include/matter/util/meta.hpp
+++ b/include/matter/util/meta.hpp
@@ -152,7 +152,8 @@ template<std::size_t N, typename... Ts>
 using nth_t = typename nth<N, Ts...>::type;
 
 template<typename T, typename TupArgs>
-struct is_constructible_expand_tuple;
+struct is_constructible_expand_tuple : std::false_type
+{};
 
 template<typename T, typename... Args>
 struct is_constructible_expand_tuple<T, std::tuple<Args...>>

--- a/test/meson.build
+++ b/test/meson.build
@@ -11,6 +11,7 @@ tests = [
   'typed_id',
   'algo',
   'group',
+  'insert_buffer',
 ]
 
 catch_lib = static_library(

--- a/test/test_entt.cpp
+++ b/test/test_entt.cpp
@@ -52,11 +52,10 @@ TEST_CASE("benchmarks")
         timer t{"Constructing 1000000 static component pairs of position and "
                 "velocity"};
 
-        std::vector<position> pos(1000000);
-        std::vector<velocity> vel(1000000);
+        auto posvel = reg.create_buffer_for<position, velocity>();
+        posvel.resize(1000000);
 
-        reg.insert(std::pair{pos.begin(), pos.end()},
-                   std::pair{vel.begin(), vel.end()});
+        reg.insert(posvel);
     }
 
     SECTION("assign_comp_runtime")
@@ -68,19 +67,19 @@ TEST_CASE("benchmarks")
         timer t{"Constructing 1000000 runtime component pairs of position and "
                 "velocity"};
 
-        std::vector<position> pos(1000000);
-        std::vector<velocity> vel(1000000);
+        auto posvel = reg.create_buffer_for<velocity, position>();
+        posvel.resize(1000000);
 
-        reg.insert(std::pair{pos.begin(), pos.end()},
-                   std::pair{vel.begin(), vel.end()});
+        reg.insert(posvel);
     }
 
     SECTION("iterate_single")
     {
         matter::registry<position, velocity> reg;
-        std::vector<position>                pos(1000000);
+        auto pos = reg.create_buffer_for<position>();
+        pos.resize(1000000);
 
-        reg.insert(std::pair{pos.begin(), pos.end()});
+        reg.insert(pos);
 
         SECTION("const")
         {
@@ -102,8 +101,8 @@ TEST_CASE("benchmarks")
 
         SECTION("iterator const")
         {
-            timer t{
-                "Iterating over 1000000 single components - const iterator"};
+            timer t{"Iterating over 1000000 single components - const "
+                    "iterator"};
 
             auto pos_view = reg.view<position>();
 
@@ -129,11 +128,10 @@ TEST_CASE("benchmarks")
     SECTION("iterate_double")
     {
         matter::registry<position, velocity> reg;
-        std::vector<position>                pos(1000000);
-        std::vector<velocity>                vel(1000000);
+        auto posvel = reg.create_buffer_for<position, velocity>();
+        posvel.resize(1000000);
 
-        reg.insert(std::pair{pos.begin(), pos.end()},
-                   std::pair{vel.begin(), vel.end()});
+        reg.insert(posvel);
 
         SECTION("const")
         {
@@ -160,14 +158,15 @@ TEST_CASE("benchmarks")
     SECTION("iterate_double,half")
     {
         matter::registry<position, velocity> reg;
-        std::vector<velocity>                vel(1000000);
+        auto vel = reg.create_buffer_for<velocity>();
+        vel.resize(1000000);
 
-        reg.insert(std::pair{vel.begin(), vel.end()});
+        reg.insert(vel);
 
-        std::vector<position> pos(1000000);
+        auto posvel = reg.create_buffer_for<position, velocity>(std::move(vel));
+        posvel.resize(1000000);
 
-        reg.insert(std::pair{pos.begin(), pos.end()},
-                   std::pair{vel.begin(), vel.end()});
+        reg.insert(posvel);
 
         SECTION("const")
         {
@@ -196,17 +195,18 @@ TEST_CASE("benchmarks")
     SECTION("iterate_single")
     {
         matter::registry<position, velocity> reg;
-        std::vector<velocity>                vel(1000000);
+        auto vel = reg.create_buffer_for<velocity>();
+        vel.resize(1000000);
 
-        reg.insert(std::pair{vel.begin(), vel.end()});
+        reg.insert(vel);
 
         reg.create<position, velocity>(std::forward_as_tuple(),
                                        std::forward_as_tuple());
 
         SECTION("const")
         {
-            timer t{
-                "Iterating over 1000000 components, only one has both - const"};
+            timer t{"Iterating over 1000000 components, only one has both "
+                    "- const"};
 
             auto view = reg.view<position, velocity>();
             view.for_each([](const position&, const velocity&) {});
@@ -214,8 +214,8 @@ TEST_CASE("benchmarks")
 
         SECTION("mutable")
         {
-            timer t{
-                "Iterating over 1000000 components, only one has both - mut"};
+            timer t{"Iterating over 1000000 components, only one has both "
+                    "- mut"};
 
             auto view = reg.view<position, velocity>();
             view.for_each([](position& pos, velocity& vel) {

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -310,20 +310,18 @@ TEST_CASE("group_vector")
         {
             auto grp =
                 grpvec3.find_group(ident.ids<float, int, short>()).value();
-            std::vector<float> fvec;
-            std::vector<int>   ivec;
-            std::vector<short> svec;
+
+            // let's try different id order
+            auto ids     = ident.ids<int, float, short>();
+            auto ifsbuff = matter::insert_buffer{ids};
+            ifsbuff.reserve(10);
 
             for (auto i = 0; i < 10; ++i)
             {
-                fvec.push_back(i);
-                ivec.push_back(i);
-                svec.push_back(i);
+                ifsbuff.push_back(i, i, i);
             }
 
-            grp.insert_back(std::pair{fvec.begin(), fvec.end()},
-                            std::pair{ivec.begin(), ivec.end()},
-                            std::pair{svec.begin(), svec.end()});
+            grp.insert_back(ifsbuff);
 
             auto view = matter::group_view{grp};
 

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -180,10 +180,14 @@ TEST_CASE("group_vector")
                     auto exact_grp =
                         matter::group(ident.ids<short, char, float>(), mut_grp);
 
+                    CHECK(exact_grp.size() == 0);
+
                     auto comp_view =
                         exact_grp.emplace_back(std::forward_as_tuple(5),
                                                std::forward_as_tuple('n'),
                                                std::forward_as_tuple(5.0f));
+
+                    CHECK(exact_grp.size() == 1);
 
                     auto [s, c, f] = comp_view;
                     CHECK(s == 5);

--- a/test/test_insert_buffer.cpp
+++ b/test/test_insert_buffer.cpp
@@ -1,0 +1,21 @@
+#include <catch2/catch.hpp>
+
+#include "matter/component/component_identifier.hpp"
+#include "matter/component/insert_buffer.hpp"
+
+TEST_CASE("insert_buffer")
+{
+    matter::component_identifier<float, int> ident{};
+    auto buf = matter::insert_buffer{ident.ids<float, int>()};
+    buf.reserve(10000);
+
+    SECTION("emplace_back")
+    {
+        buf.emplace_back(std::forward_as_tuple(5.5f),
+                         std::forward_as_tuple(50));
+        CHECK(buf.size() == 1);
+
+        buf.emplace_back(5.5f, 50);
+        CHECK(buf.size() == 2);
+    }
+}

--- a/test/test_registry.cpp
+++ b/test/test_registry.cpp
@@ -106,8 +106,8 @@ TEST_CASE("registry")
 
         SECTION("fill view")
         {
-            float                   f1{};
-            std::vector<float_comp> fvec;
+            float f1{};
+            auto  fvec = reg.create_buffer_for<float_comp>();
             fvec.reserve(10000);
 
             for (auto i = 0; i < 10000; ++i)
@@ -116,7 +116,7 @@ TEST_CASE("registry")
                 fvec.emplace_back(f1);
             }
 
-            reg.insert(std::pair{fvec.begin(), fvec.end()});
+            reg.insert(fvec);
 
             SECTION("read view")
             {
@@ -162,19 +162,15 @@ TEST_CASE("registry")
                 }
             }
 
-            std::vector<float_comp> fvec2;
-            fvec2.reserve(10000);
-            std::vector<int_comp> ivec;
-            ivec.reserve(10000);
+            auto fibuff = reg.create_buffer_for<float_comp, int_comp>();
+            fibuff.reserve(10000);
 
             for (auto i = 0; i < 10000; ++i)
             {
-                fvec2.emplace_back(1.0f);
-                ivec.emplace_back(1);
+                fibuff.emplace_back(1.0f, 1);
             }
 
-            reg.insert(std::pair{fvec2.begin(), fvec2.end()},
-                       std::pair{ivec.begin(), ivec.end()});
+            reg.insert(fibuff);
 
             SECTION("check multiple component views")
             {


### PR DESCRIPTION
Insertions are now done with `insert_buffer` which can be created with `registry::create_buffer_for<Cs...>()`. This guarantees proper equal sizes for all components which will be inserted and no (un)intentional contract violations can occur.

Additionally size information is stored per group. This removes reliance on the containers implementing `size()` which might not always be as fast but let's be honest it probably is. I guess I'll remove it since it adds a lot of potential for errors.