### PR TITLE
Insert buffer guarantees the insertion contract

### DIFF
--- a/include/matter/component/insert_buffer.hpp
+++ b/include/matter/component/insert_buffer.hpp
@@ -1,0 +1,180 @@
+#ifndef MATTER_COMPONENT_INSERT_BUFFER_HPP
+#define MATTER_COMPONENT_INSERT_BUFFER_HPP
+
+#pragma once
+
+#include <vector>
+
+#include "matter/component/typed_id.hpp"
+#include "matter/util/meta.hpp"
+
+namespace matter
+{
+template<typename UnorderedTypedIds>
+struct insert_buffer;
+
+template<typename Id, typename... TIds>
+struct insert_buffer<matter::unordered_typed_ids<Id, TIds...>>
+{
+    using id_type = Id;
+
+private:
+    template<typename UnorderedTypedIds>
+    friend struct insert_buffer;
+
+private:
+    matter::unordered_typed_ids<Id, TIds...>        ids_;
+    std::tuple<std::vector<typename TIds::type>...> buffers_;
+
+public:
+    insert_buffer(const matter::unordered_typed_ids<Id, TIds...>& ids) noexcept
+        : ids_{ids}, buffers_{}
+    {}
+
+    template<typename... UTIds>
+    insert_buffer(
+        const matter::unordered_typed_ids<Id, TIds...>& ids,
+        matter::insert_buffer<matter::unordered_typed_ids<Id, UTIds...>>&&
+            move_from) noexcept
+        : ids_{ids}, buffers_{[&]() {
+              // this will take the vector from the passed buffer and use any
+              // buffer that we also have in the current buffer
+              if constexpr (detail::type_in_list_v<typename TIds::type,
+                                                   typename UTIds::type...>)
+              {
+                  auto vec = std::vector<typename TIds::type>{
+                      std::move(move_from.template get<typename TIds::type>())};
+                  vec.clear();
+                  return vec;
+              }
+              else
+              {
+                  return std::vector<typename TIds::type>{};
+              }
+          }()...}
+    {}
+
+    template<typename T>
+    constexpr auto begin() noexcept
+    {
+        return get<T>().begin();
+    }
+
+    template<typename T>
+    constexpr auto end() noexcept
+    {
+        return get<T>().end();
+    }
+
+    template<typename T>
+    constexpr auto begin() const noexcept
+    {
+        return get<T>().begin();
+    }
+
+    template<typename T>
+    constexpr auto end() const noexcept
+    {
+        return get<T>().end();
+    }
+
+    const auto& ids() const noexcept
+    {
+        return ids_;
+    }
+
+    std::size_t size() const noexcept
+    {
+        // all buffers are guaranteed to be the same size
+        return std::get<0>(buffers_).size();
+    }
+
+    void reserve(std::size_t new_capacity) noexcept
+    {
+        return std::apply(
+            [&](auto&&... buffers) { (buffers.reserve(new_capacity), ...); },
+            buffers_);
+    }
+
+    void resize(std::size_t new_size) noexcept(
+        (std::is_nothrow_default_constructible_v<typename TIds::type> && ...))
+    {
+        return std::apply(
+            [&](auto&&... buffers) { (buffers.resize(new_size), ...); },
+            buffers_);
+    }
+
+    void resize(std::size_t new_size, const typename TIds::type... ts) noexcept(
+        (std::is_nothrow_copy_constructible_v<typename TIds::type> && ...))
+    {
+        (get<typename TIds::type>().resize(new_size, ts), ...);
+    }
+
+    template<typename... TupArgs>
+    std::enable_if_t<(
+        detail::is_constructible_expand_tuple_v<typename TIds::type, TupArgs> &&
+        ...)>
+    emplace_back(TupArgs&&... tuple_args) noexcept(
+        (detail::is_nothrow_constructible_expand_tuple_v<typename TIds::type,
+                                                         TupArgs> &&
+         ...))
+    {
+        (emplace_one_impl<typename TIds::type>(
+             std::forward<TupArgs>(tuple_args)),
+         ...);
+    }
+
+    template<typename... Args>
+    std::enable_if_t<sizeof...(Args) == sizeof...(TIds) &&
+                     (std::is_constructible_v<typename TIds::type, Args> &&
+                      ...)>
+    emplace_back(Args&&... args) noexcept(
+        (std::is_nothrow_constructible_v<typename TIds::type, Args> && ...))
+    {
+        (get<typename TIds::type>().emplace_back(std::forward<Args>(args)),
+         ...);
+    }
+
+    template<typename... Ts>
+    std::enable_if_t<sizeof...(Ts) == sizeof...(TIds) &&
+                     (std::is_constructible_v<typename TIds::type, const Ts&> &&
+                      ...)>
+    push_back(const Ts&... ts) noexcept((
+        std::is_nothrow_constructible_v<typename TIds::type, const Ts&> && ...))
+    {
+        (get<typename TIds::type>().push_back(ts), ...);
+    }
+
+private:
+    template<typename T, typename... Args>
+    void emplace_one_impl(std::tuple<Args...> tuple_args) noexcept(
+        std::is_nothrow_constructible_v<T, Args...>)
+    {
+        get<T>().emplace_back(std::get<Args>(tuple_args)...);
+    }
+
+    template<typename T>
+    auto& get() noexcept
+    {
+        return std::get<std::vector<T>>(buffers_);
+    }
+
+    template<typename T>
+    const auto& get() const noexcept
+    {
+        return std::get<std::vector<T>>(buffers_);
+    }
+};
+
+template<typename UnorderedIdsType>
+insert_buffer(
+    const UnorderedIdsType& ids) noexcept->insert_buffer<UnorderedIdsType>;
+
+template<typename UnorderedTypedIds, typename OtherUnorderedTypedIds>
+insert_buffer(const UnorderedTypedIds& ids,
+              matter::insert_buffer<OtherUnorderedTypedIds>&&
+                  move_from) noexcept->insert_buffer<UnorderedTypedIds>;
+
+} // namespace matter
+
+#endif

--- a/include/matter/util/meta.hpp
+++ b/include/matter/util/meta.hpp
@@ -152,7 +152,8 @@ template<std::size_t N, typename... Ts>
 using nth_t = typename nth<N, Ts...>::type;
 
 template<typename T, typename TupArgs>
-struct is_constructible_expand_tuple;
+struct is_constructible_expand_tuple : std::false_type
+{};
 
 template<typename T, typename... Args>
 struct is_constructible_expand_tuple<T, std::tuple<Args...>>

--- a/test/meson.build
+++ b/test/meson.build
@@ -11,6 +11,7 @@ tests = [
   'typed_id',
   'algo',
   'group',
+  'insert_buffer',
 ]
 
 catch_lib = static_library(

--- a/test/test_entt.cpp
+++ b/test/test_entt.cpp
@@ -52,11 +52,10 @@ TEST_CASE("benchmarks")
         timer t{"Constructing 1000000 static component pairs of position and "
                 "velocity"};
 
-        std::vector<position> pos(1000000);
-        std::vector<velocity> vel(1000000);
+        auto posvel = reg.create_buffer_for<position, velocity>();
+        posvel.resize(1000000);
 
-        reg.insert(std::pair{pos.begin(), pos.end()},
-                   std::pair{vel.begin(), vel.end()});
+        reg.insert(posvel);
     }
 
     SECTION("assign_comp_runtime")
@@ -68,19 +67,19 @@ TEST_CASE("benchmarks")
         timer t{"Constructing 1000000 runtime component pairs of position and "
                 "velocity"};
 
-        std::vector<position> pos(1000000);
-        std::vector<velocity> vel(1000000);
+        auto posvel = reg.create_buffer_for<velocity, position>();
+        posvel.resize(1000000);
 
-        reg.insert(std::pair{pos.begin(), pos.end()},
-                   std::pair{vel.begin(), vel.end()});
+        reg.insert(posvel);
     }
 
     SECTION("iterate_single")
     {
         matter::registry<position, velocity> reg;
-        std::vector<position>                pos(1000000);
+        auto pos = reg.create_buffer_for<position>();
+        pos.resize(1000000);
 
-        reg.insert(std::pair{pos.begin(), pos.end()});
+        reg.insert(pos);
 
         SECTION("const")
         {
@@ -102,8 +101,8 @@ TEST_CASE("benchmarks")
 
         SECTION("iterator const")
         {
-            timer t{
-                "Iterating over 1000000 single components - const iterator"};
+            timer t{"Iterating over 1000000 single components - const "
+                    "iterator"};
 
             auto pos_view = reg.view<position>();
 
@@ -129,11 +128,10 @@ TEST_CASE("benchmarks")
     SECTION("iterate_double")
     {
         matter::registry<position, velocity> reg;
-        std::vector<position>                pos(1000000);
-        std::vector<velocity>                vel(1000000);
+        auto posvel = reg.create_buffer_for<position, velocity>();
+        posvel.resize(1000000);
 
-        reg.insert(std::pair{pos.begin(), pos.end()},
-                   std::pair{vel.begin(), vel.end()});
+        reg.insert(posvel);
 
         SECTION("const")
         {
@@ -160,14 +158,15 @@ TEST_CASE("benchmarks")
     SECTION("iterate_double,half")
     {
         matter::registry<position, velocity> reg;
-        std::vector<velocity>                vel(1000000);
+        auto vel = reg.create_buffer_for<velocity>();
+        vel.resize(1000000);
 
-        reg.insert(std::pair{vel.begin(), vel.end()});
+        reg.insert(vel);
 
-        std::vector<position> pos(1000000);
+        auto posvel = reg.create_buffer_for<position, velocity>(std::move(vel));
+        posvel.resize(1000000);
 
-        reg.insert(std::pair{pos.begin(), pos.end()},
-                   std::pair{vel.begin(), vel.end()});
+        reg.insert(posvel);
 
         SECTION("const")
         {
@@ -196,17 +195,18 @@ TEST_CASE("benchmarks")
     SECTION("iterate_single")
     {
         matter::registry<position, velocity> reg;
-        std::vector<velocity>                vel(1000000);
+        auto vel = reg.create_buffer_for<velocity>();
+        vel.resize(1000000);
 
-        reg.insert(std::pair{vel.begin(), vel.end()});
+        reg.insert(vel);
 
         reg.create<position, velocity>(std::forward_as_tuple(),
                                        std::forward_as_tuple());
 
         SECTION("const")
         {
-            timer t{
-                "Iterating over 1000000 components, only one has both - const"};
+            timer t{"Iterating over 1000000 components, only one has both "
+                    "- const"};
 
             auto view = reg.view<position, velocity>();
             view.for_each([](const position&, const velocity&) {});
@@ -214,8 +214,8 @@ TEST_CASE("benchmarks")
 
         SECTION("mutable")
         {
-            timer t{
-                "Iterating over 1000000 components, only one has both - mut"};
+            timer t{"Iterating over 1000000 components, only one has both "
+                    "- mut"};
 
             auto view = reg.view<position, velocity>();
             view.for_each([](position& pos, velocity& vel) {

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -310,20 +310,18 @@ TEST_CASE("group_vector")
         {
             auto grp =
                 grpvec3.find_group(ident.ids<float, int, short>()).value();
-            std::vector<float> fvec;
-            std::vector<int>   ivec;
-            std::vector<short> svec;
+
+            // let's try different id order
+            auto ids     = ident.ids<int, float, short>();
+            auto ifsbuff = matter::insert_buffer{ids};
+            ifsbuff.reserve(10);
 
             for (auto i = 0; i < 10; ++i)
             {
-                fvec.push_back(i);
-                ivec.push_back(i);
-                svec.push_back(i);
+                ifsbuff.push_back(i, i, i);
             }
 
-            grp.insert_back(std::pair{fvec.begin(), fvec.end()},
-                            std::pair{ivec.begin(), ivec.end()},
-                            std::pair{svec.begin(), svec.end()});
+            grp.insert_back(ifsbuff);
 
             auto view = matter::group_view{grp};
 

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -180,10 +180,14 @@ TEST_CASE("group_vector")
                     auto exact_grp =
                         matter::group(ident.ids<short, char, float>(), mut_grp);
 
+                    CHECK(exact_grp.size() == 0);
+
                     auto comp_view =
                         exact_grp.emplace_back(std::forward_as_tuple(5),
                                                std::forward_as_tuple('n'),
                                                std::forward_as_tuple(5.0f));
+
+                    CHECK(exact_grp.size() == 1);
 
                     auto [s, c, f] = comp_view;
                     CHECK(s == 5);

--- a/test/test_insert_buffer.cpp
+++ b/test/test_insert_buffer.cpp
@@ -1,0 +1,21 @@
+#include <catch2/catch.hpp>
+
+#include "matter/component/component_identifier.hpp"
+#include "matter/component/insert_buffer.hpp"
+
+TEST_CASE("insert_buffer")
+{
+    matter::component_identifier<float, int> ident{};
+    auto buf = matter::insert_buffer{ident.ids<float, int>()};
+    buf.reserve(10000);
+
+    SECTION("emplace_back")
+    {
+        buf.emplace_back(std::forward_as_tuple(5.5f),
+                         std::forward_as_tuple(50));
+        CHECK(buf.size() == 1);
+
+        buf.emplace_back(5.5f, 50);
+        CHECK(buf.size() == 2);
+    }
+}

--- a/test/test_registry.cpp
+++ b/test/test_registry.cpp
@@ -106,8 +106,8 @@ TEST_CASE("registry")
 
         SECTION("fill view")
         {
-            float                   f1{};
-            std::vector<float_comp> fvec;
+            float f1{};
+            auto  fvec = reg.create_buffer_for<float_comp>();
             fvec.reserve(10000);
 
             for (auto i = 0; i < 10000; ++i)
@@ -116,7 +116,7 @@ TEST_CASE("registry")
                 fvec.emplace_back(f1);
             }
 
-            reg.insert(std::pair{fvec.begin(), fvec.end()});
+            reg.insert(fvec);
 
             SECTION("read view")
             {
@@ -162,19 +162,15 @@ TEST_CASE("registry")
                 }
             }
 
-            std::vector<float_comp> fvec2;
-            fvec2.reserve(10000);
-            std::vector<int_comp> ivec;
-            ivec.reserve(10000);
+            auto fibuff = reg.create_buffer_for<float_comp, int_comp>();
+            fibuff.reserve(10000);
 
             for (auto i = 0; i < 10000; ++i)
             {
-                fvec2.emplace_back(1.0f);
-                ivec.emplace_back(1);
+                fibuff.emplace_back(1.0f, 1);
             }
 
-            reg.insert(std::pair{fvec2.begin(), fvec2.end()},
-                       std::pair{ivec.begin(), ivec.end()});
+            reg.insert(fibuff);
 
             SECTION("check multiple component views")
             {


### PR DESCRIPTION
Insertions are now done with `insert_buffer` which can be created with `registry::create_buffer_for<Cs...>()`. This guarantees proper equal sizes for all components which will be inserted and no (un)intentional contract violations can occur.