### PR TITLE
Implement erasing an entity from the registry

### DIFF
--- a/include/matter/component/any_group.hpp
+++ b/include/matter/component/any_group.hpp
@@ -31,7 +31,8 @@ private:
     friend class any_group;
 
 public:
-    using id_type = typename matter::erased_storage::id_type;
+    using id_type   = typename matter::erased_storage::id_type;
+    using size_type = typename matter::erased_storage::size_type;
 
     using const_iterator = const matter::erased_storage*;
     using iterator =
@@ -122,6 +123,13 @@ public:
     constexpr erased_type data() noexcept
     {
         return ptr_;
+    }
+
+    constexpr void erase(size_type idx) noexcept
+    {
+        std::for_each(begin(), end(), [&](auto&& erased_storage) {
+            erased_storage.erase(idx);
+        });
     }
 
     constexpr const matter::erased_storage* data() const noexcept

--- a/include/matter/component/group_vector_view.hpp
+++ b/include/matter/component/group_vector_view.hpp
@@ -69,6 +69,16 @@ public:
             return it_;
         }
 
+        constexpr const auto& ids() const noexcept
+        {
+            return ids_;
+        }
+
+        constexpr const auto& ordered_ids() const noexcept
+        {
+            return ordered_ids_;
+        }
+
         constexpr auto group_size() const noexcept
         {
             return base().group_size();

--- a/include/matter/component/group_vector_view.hpp
+++ b/include/matter/component/group_vector_view.hpp
@@ -413,6 +413,16 @@ public:
         assert(ids.size() <= group_vec.group_size());
     }
 
+    constexpr auto& base() noexcept
+    {
+        return group_vec_.get();
+    }
+
+    constexpr const auto& base() const noexcept
+    {
+        return group_vec_.get();
+    }
+
     constexpr iterator begin() noexcept
     {
         return iterator{ids_,

--- a/include/matter/component/group_view.hpp
+++ b/include/matter/component/group_view.hpp
@@ -272,9 +272,11 @@ public:
 
     constexpr component_view<Cs...> operator[](std::size_t index) noexcept
     {
-        return std::apply([index](auto&... stores) {
-            return component_view{stores[index]...};
-        });
+        return std::apply(
+            [index](auto&&... stores) {
+                return component_view{stores.get()[index]...};
+            },
+            stores_);
     }
 
     template<typename T>

--- a/include/matter/component/group_view.hpp
+++ b/include/matter/component/group_view.hpp
@@ -225,6 +225,7 @@ public:
     };
 
 private:
+    any_group grp_;
     std::tuple<std::reference_wrapper<matter::component_storage_t<Cs>>...>
         stores_;
 
@@ -232,12 +233,17 @@ public:
     template<typename Id, typename... TIds>
     constexpr group_view(const unordered_typed_ids<Id, TIds...>& ids,
                          any_group&                              grp) noexcept
-        : stores_{grp.storage(ids)}
+        : grp_{grp}, stores_{grp.storage(ids)}
     {}
 
     constexpr group_view(const group<Cs...>& grp) noexcept
-        : stores_{grp.stores_}
+        : grp_{grp.underlying_group()}, stores_{grp.stores_}
     {}
+
+    constexpr any_group underlying_group() const noexcept
+    {
+        return grp_;
+    }
 
     template<typename Id>
     constexpr auto operator==(const group<Id, Cs...>& grp) const noexcept
@@ -321,14 +327,14 @@ public:
         return sentinel{get<Cs>().end()...};
     }
 
-    constexpr auto size() const noexcept
+    constexpr std::size_t size() const noexcept
     {
-        return std::get<0>(stores_).get().size();
+        return get<0>().size();
     }
 
     constexpr auto empty() const noexcept
     {
-        return std::get<0>(stores_).get().empty();
+        return get<0>().empty();
     }
 };
 

--- a/include/matter/component/registry.hpp
+++ b/include/matter/component/registry.hpp
@@ -119,6 +119,13 @@ public:
         ideal_group.insert_back(buffer);
     }
 
+    template<typename GroupViewIterator>
+    void erase(GroupViewIterator it, std::size_t idx) noexcept
+    {
+        auto grp = (*it).underlying_group();
+        grp.erase(idx);
+    }
+
 private:
     template<typename... Ts>
     group<typename Ts::type...>

--- a/include/matter/component/registry_view.hpp
+++ b/include/matter/component/registry_view.hpp
@@ -378,16 +378,17 @@ public:
         matter::for_each(
             it, end_, [ids = ids_, f = std::move(f)](group_vector& grp_vec) {
                 matter::group_vector_view view{ids, grp_vec};
-                matter::for_each(view.begin(),
-                                 view.end(),
-                                 [f = std::move(f)](auto grp_view) {
-                                     matter::for_each(
-                                         grp_view.begin(),
-                                         grp_view.end(),
-                                         [f = std::move(f)](auto comp_view) {
-                                             comp_view.invoke(std::move(f));
-                                         });
-                                 });
+                matter::for_each(
+                    view.begin(),
+                    view.end(),
+                    [f = std::move(f)](auto grp_view) {
+#pragma omp simd
+                        for (std::size_t i = 0; i < grp_view.size(); ++i)
+                        {
+                            auto comp_view = grp_view[i];
+                            comp_view.invoke(std::move(f));
+                        }
+                    });
             });
     }
 };

--- a/include/matter/component/registry_view.hpp
+++ b/include/matter/component/registry_view.hpp
@@ -191,6 +191,147 @@ struct registry_view<matter::unordered_typed_ids<Id, TIds...>>
         }
     };
 
+    struct group_view_iterator
+    {
+        using group_vector_container_type = std::vector<group_vector>;
+        using group_vector_container_iterator_type =
+            matter::iterator_t<group_vector_container_type>;
+        using group_vector_container_sentinel_type =
+            matter::sentinel_t<group_vector_container_type>;
+
+        using group_vector_view_type = decltype(matter::group_vector_view{
+            std::declval<unordered_ids_type>(),
+            *std::declval<group_vector_container_iterator_type>()});
+        using group_vector_view_iterator_type =
+            matter::iterator_t<group_vector_view_type>;
+        using group_vector_view_sentinel_type =
+            matter::sentinel_t<group_vector_view_type>;
+
+        using value_type        = group_view<typename TIds::type...>;
+        using reference         = value_type;
+        using pointer           = void;
+        using iterator_category = std::forward_iterator_tag;
+
+    private:
+        group_vector_container_iterator_type grp_vec_container_it_;
+        group_vector_container_sentinel_type grp_vec_container_sent_;
+
+        group_vector_view_iterator_type grp_vec_view_it_;
+        group_vector_view_sentinel_type grp_vec_view_sent_;
+
+    public:
+        constexpr group_view_iterator(
+            const unordered_ids_type&            ids,
+            group_vector_container_iterator_type begin_range,
+            group_vector_container_sentinel_type end_range) noexcept
+            : grp_vec_container_it_{begin_range + ids.size()},
+              grp_vec_container_sent_{end_range}, grp_vec_view_it_{[&]() {
+                  auto grp_vec_view =
+                      group_vector_view_type{ids, *grp_vec_container_it_};
+                  return grp_vec_view.begin();
+              }()},
+              grp_vec_view_sent_{
+                  typename group_vector_view<unordered_ids_type>::sentinel{}}
+        {
+
+            if (grp_vec_view_it_ != grp_vec_view_sent_)
+            {
+                // the group_vector_view is not empty, hooray
+                return;
+            }
+            while (++grp_vec_container_it_ < grp_vec_container_sent_)
+            {
+                auto grp_vec_view = group_vector_view_type{
+                    grp_vec_view_it_.ids(), *grp_vec_container_it_};
+                grp_vec_view_it_   = grp_vec_view.begin();
+                grp_vec_view_sent_ = grp_vec_view.end();
+
+                if (grp_vec_view_it_ != grp_vec_view_sent_)
+                {
+                    // finally a non empty group_vector_view, after months of
+                    // iterations
+                    return;
+                }
+            }
+        }
+
+        constexpr group_view_iterator& operator++() noexcept
+        {
+            // we hit the end of our current group_vector_view, let's move up
+            if (++grp_vec_view_it_ == grp_vec_view_sent_)
+            {
+                do
+                {
+                    if (++grp_vec_container_it_ == grp_vec_container_sent_)
+                    {
+                        // we hit the end, nothing left to do
+                        return *this;
+                    }
+                    else
+                    {
+                        auto grp_vec_view = group_vector_view_type{
+                            ids(), *grp_vec_container_it_};
+                        grp_vec_view_it_   = grp_vec_view.begin();
+                        grp_vec_view_sent_ = grp_vec_view.end();
+                    }
+                } while (grp_vec_view_it_ == grp_vec_view_sent_);
+            }
+
+            return *this;
+        }
+
+        constexpr reference operator*() const noexcept
+        {
+            return *grp_vec_view_it_;
+        }
+
+        constexpr const auto& ids() const noexcept
+        {
+            return grp_vec_view_it_.ids();
+        }
+
+        constexpr const auto& ordered_ids() const noexcept
+        {
+            return grp_vec_view_it_.ordered_ids();
+        }
+
+        constexpr auto is_beyond_end() const noexcept
+        {
+            return grp_vec_container_it_ >= grp_vec_container_sent_;
+        }
+    };
+
+    struct group_view_sentinel
+    {
+        constexpr group_view_sentinel() noexcept = default;
+
+        constexpr auto operator==(const group_view_iterator& it) const noexcept
+        {
+            // use >= over == because the begin can be higher than end on
+            // instantiation
+            return it.is_beyond_end();
+        }
+
+        constexpr auto operator!=(const group_view_iterator& it) const noexcept
+        {
+            return !(*this == it);
+        }
+
+        constexpr friend auto
+        operator==(const group_view_iterator& it,
+                   const group_view_sentinel& sent) noexcept
+        {
+            return sent == it;
+        }
+
+        constexpr friend auto
+        operator!=(const group_view_iterator& it,
+                   const group_view_sentinel& sent) noexcept
+        {
+            return sent != it;
+        }
+    };
+
 private:
     unordered_ids_type                            ids_;
     matter::iterator_t<std::vector<group_vector>> begin_;
@@ -212,6 +353,16 @@ public:
     constexpr sentinel end() const noexcept
     {
         return sentinel{};
+    }
+
+    constexpr group_view_iterator group_view_begin() noexcept
+    {
+        return group_view_iterator{ids_, begin_, end_};
+    }
+
+    constexpr group_view_sentinel group_view_end() noexcept
+    {
+        return group_view_sentinel{};
     }
 
     template<typename Function>

--- a/include/matter/component/registry_view.hpp
+++ b/include/matter/component/registry_view.hpp
@@ -391,6 +391,21 @@ public:
                     });
             });
     }
+
+    /// erase the entity at index idx of group at it, all components will be
+    /// removed with the entity
+    void erase(const group_view_iterator& it, std::size_t idx) noexcept
+    {
+        // this is where the to be erased entity lies
+        auto any_grp = (*it).underlying_group();
+        any_grp.erase(idx);
+    }
+
+    /// remove the components from iterator at it
+    /// this will move the entity to a different group
+    template<typename... Cs>
+    void detach(const iterator& it)
+    {}
 };
 
 template<typename Id, typename... TIds>

--- a/include/matter/storage/erased_storage.hpp
+++ b/include/matter/storage/erased_storage.hpp
@@ -75,7 +75,16 @@ public:
           erase_fn_{[](matter::erased& er_storage, size_type idx) {
               auto& storage =
                   er_storage.template get<matter::component_storage_t<C>>();
-              storage.erase(std::begin(storage) + idx);
+              if constexpr (matter::has_erase_for<
+                                matter::component_storage_t<C>,
+                                size_type>::value)
+              {
+                  storage.erase(idx);
+              }
+              else
+              {
+                  storage.erase(std::begin(storage) + idx);
+              }
           }}
     {
         static_assert(matter::is_component_v<C>,

--- a/include/matter/util/concepts.hpp
+++ b/include/matter/util/concepts.hpp
@@ -51,6 +51,18 @@ template<typename T>
 struct has_pre_increment<T, std::void_t<decltype(++std::declval<T&>())>>
     : std::true_type
 {};
+
+template<typename T, typename It, typename = void>
+struct has_erase_for : std::false_type
+{};
+
+template<typename T, typename It>
+struct has_erase_for<
+    T,
+    It,
+    std::void_t<decltype(std::declval<T&>().erase(std::declval<It>()))>>
+    : std::true_type
+{};
 } // namespace matter
 
 #endif

--- a/test/test_entt.cpp
+++ b/test/test_entt.cpp
@@ -122,6 +122,45 @@ TEST_CASE("benchmarks")
                         [](position& position) { position.x = {}; });
                 });
         }
+
+        SECTION("group_view_iterator const")
+        {
+            timer t{"Iterating over 1000000 single components - const "
+                    "group_view_iterator"};
+
+            auto pos_view = reg.view<position>();
+
+            matter::for_each(pos_view.group_view_begin(),
+                             pos_view.group_view_end(),
+                             [](auto grp_view) {
+                                 auto sz = grp_view.size();
+#pragma omp simd
+                                 for (std::size_t i = 0; i < sz; ++i)
+                                 {
+                                     grp_view[i].invoke([](const position&) {});
+                                 }
+                             });
+        }
+
+        SECTION("group_view_iterator const")
+        {
+            timer t{"Iterating over 1000000 single components - const "
+                    "group_view_iterator"};
+
+            auto pos_view = reg.view<position>();
+
+            matter::for_each(pos_view.group_view_begin(),
+                             pos_view.group_view_end(),
+                             [](auto grp_view) {
+                                 auto sz = grp_view.size();
+#pragma omp simd
+                                 for (std::size_t i = 0; i < sz; ++i)
+                                 {
+                                     grp_view[i].invoke(
+                                         [](position& pos) { pos.x = {}; });
+                                 }
+                             });
+        }
     }
     // TODO: test destroying
 

--- a/test/test_registry.cpp
+++ b/test/test_registry.cpp
@@ -223,5 +223,18 @@ TEST_CASE("registry")
         iview.for_each([&](auto&&...) { ++n; });
         // the only inct_comp should be gone
         CHECK(n == 0);
+
+        auto it1 = fview.group_view_begin();
+        // erase through the registry method
+        reg.erase(it1, 0);
+
+        n = 0;
+        fview.for_each([&](auto&&...) { ++n; });
+        // all float_comp entities are also erased now
+        CHECK(n == 0);
+
+        n = 0;
+        iview.for_each([&](auto&&...) { ++n; });
+        CHECK(n == 0);
     }
 }

--- a/test/test_registry.cpp
+++ b/test/test_registry.cpp
@@ -191,4 +191,37 @@ TEST_CASE("registry")
             }
         }
     }
+
+    SECTION("erase")
+    {
+        reg.create<float_comp>(std::forward_as_tuple(5.0f));
+        reg.create<float_comp, int_comp>(std::forward_as_tuple(5.0f),
+                                         std::forward_as_tuple(5));
+
+        int  n     = 0;
+        auto fview = reg.view<float_comp>();
+        fview.for_each([&](auto&&...) { ++n; });
+
+        CHECK(n == 2);
+
+        n          = 0;
+        auto iview = reg.view<int_comp>();
+        iview.for_each([&](auto&&...) { ++n; });
+        CHECK(n == 1);
+
+        auto it = iview.group_view_begin();
+        CHECK(it != iview.group_view_end());
+        // should be at index 0 within the group
+        iview.erase(it, 0);
+
+        n = 0;
+        fview.for_each([&](auto&&...) { ++n; });
+        // a float component should be gone
+        CHECK(n == 1);
+
+        n = 0;
+        iview.for_each([&](auto&&...) { ++n; });
+        // the only inct_comp should be gone
+        CHECK(n == 0);
+    }
 }


### PR DESCRIPTION
Allow to erase an entity using a `group_view_iterator` and the index of the entity within the group.