### PR TITLE
Implementation for detaching components from entities

### DIFF
--- a/include/matter/component/registry.hpp
+++ b/include/matter/component/registry.hpp
@@ -122,6 +122,8 @@ public:
     template<typename GroupViewIterator>
     void erase(GroupViewIterator it, std::size_t idx) noexcept
     {
+        // need to use the very abstract GroupViewIterator because otherwise
+        // template deduction doesn't work at all
         auto grp = (*it).underlying_group();
         grp.erase(idx);
     }

--- a/include/matter/component/untyped_id.hpp
+++ b/include/matter/component/untyped_id.hpp
@@ -1,0 +1,141 @@
+#ifndef MATTER_COMPONENT_UNTYPED_ID_HPP
+#define MATTER_COMPONENT_UNTYPED_ID_HPP
+
+#pragma once
+
+#include <algorithm>
+
+#include "matter/util/algorithm.hpp"
+
+namespace matter
+{
+template<typename Id>
+struct unordered_untyped_ids
+{
+    using id_type        = Id;
+    using size_type      = std::size_t;
+    using iterator       = id_type*;
+    using const_iterator = const id_type*;
+
+private:
+    id_type*  ids_;
+    size_type size_;
+
+public:
+    constexpr unordered_untyped_ids(id_type* ids, size_type size) noexcept
+        : ids_{ids}, size_{size}
+    {}
+
+    constexpr iterator begin() noexcept
+    {
+        return data();
+    }
+
+    constexpr iterator end() noexcept
+    {
+        return data() + size();
+    }
+
+    constexpr const_iterator begin() const noexcept
+    {
+        return data();
+    }
+
+    constexpr const_iterator end() const noexcept
+    {
+        return data() + size();
+    }
+
+    constexpr const_iterator cbegin() const noexcept
+    {
+        return data();
+    }
+
+    constexpr const_iterator cend() const noexcept
+    {
+        return data() + size();
+    }
+
+    constexpr id_type* data() noexcept
+    {
+        return ids_;
+    }
+
+    constexpr const id_type data() const noexcept
+    {
+        return ids_;
+    }
+
+    constexpr size_type size() const noexcept
+    {
+        return size_;
+    }
+
+    constexpr id_type& operator[](size_type index) noexcept
+    {
+        assert(index < size());
+        return ids_[index];
+    }
+
+    constexpr const id_type& operator[](size_type index) const noexcept
+    {
+        assert(index < size());
+        return ids_[index];
+    }
+};
+
+template<typename Id>
+struct ordered_untyped_ids
+{
+    using id_type   = Id;
+    using size_type = std::size_t;
+
+    using iterator       = id_type*;
+    using const_iterator = const id_type*;
+
+private:
+    id_type*  ids_;
+    size_type size_;
+
+public:
+    constexpr ordered_untyped_ids(id_type* ids, size_type size) noexcept
+        : ids_{ids}, size_{size}
+    {
+        matter::insertion_sort(ids_, ids_ + this->size());
+    }
+
+    constexpr const_iterator begin() const noexcept
+    {
+        return ids_;
+    }
+
+    constexpr const_iterator end() const noexcept
+    {
+        return ids_ + size_;
+    }
+
+    constexpr size_type size() const noexcept
+    {
+        return size_;
+    }
+
+    constexpr const id_type* data() const noexcept
+    {
+        return ids_;
+    }
+
+    constexpr id_type& operator[](std::size_t idx) noexcept
+    {
+        assert(idx < size());
+        return ids_[idx];
+    }
+
+    constexpr const id_type& operator[](std::size_t idx) const noexcept
+    {
+        assert(idx < size());
+        return ids_[idx];
+    }
+};
+} // namespace matter
+
+#endif

--- a/include/matter/util/algorithm.hpp
+++ b/include/matter/util/algorithm.hpp
@@ -113,7 +113,7 @@ for_each(ExecutionPolicy&&,
         // calculate the bounds of vectorization
 
 #pragma omp simd
-        for (auto it = first; it < last; ++first)
+        for (auto it = first; it < last; ++it)
         {
             f(*it);
         }
@@ -208,7 +208,7 @@ rotate(ForwardIt first, ForwardIt n_first, ForwardIt last) noexcept
         matter::iter_swap(write++, read++);
     }
 
-    rotate(write, next_read, last);
+    matter::rotate(write, next_read, last);
     return write;
 }
 

--- a/include/matter/util/erased.hpp
+++ b/include/matter/util/erased.hpp
@@ -92,7 +92,7 @@ public:
     template<typename T>
     constexpr const T& get() const noexcept
     {
-        return *static_cast<T*>(get_void());
+        return *static_cast<const T*>(get_void());
     }
 
     friend void swap(erased& lhs, erased& rhs) noexcept;

--- a/include/matter/util/meta.hpp
+++ b/include/matter/util/meta.hpp
@@ -151,6 +151,18 @@ struct nth<0, T, Ts...>
 template<std::size_t N, typename... Ts>
 using nth_t = typename nth<N, Ts...>::type;
 
+template<typename... Ts>
+struct first;
+
+template<typename T, typename... Ts>
+struct first<T, Ts...>
+{
+    using type = T;
+};
+
+template<typename... Ts>
+using first_t = typename first<Ts...>::type;
+
 template<typename T, typename TupArgs>
 struct is_constructible_expand_tuple : std::false_type
 {};

--- a/test/test_entt.cpp
+++ b/test/test_entt.cpp
@@ -162,7 +162,27 @@ TEST_CASE("benchmarks")
                              });
         }
     }
-    // TODO: test destroying
+
+    SECTION("destroy")
+    {
+        matter::registry<position> reg;
+
+        auto buff = reg.create_buffer_for<position>();
+        buff.resize(1000000);
+
+        reg.insert(buff);
+
+        timer t{"Destroying 1000000 entities"};
+
+        auto pos_view = reg.view<position>();
+        auto it       = pos_view.group_view_begin();
+        for (std::size_t i = 999999; i != 0; --i)
+        {
+            pos_view.erase(it, i);
+        }
+
+        pos_view.erase(it, 0);
+    }
 
     SECTION("iterate_double")
     {

--- a/test/test_typed_id.cpp
+++ b/test/test_typed_id.cpp
@@ -35,6 +35,20 @@ TEST_CASE("typed_id")
             auto ordered1  = ident.ordered_ids<float, short, char>();
             auto rt_order1 = ident.ordered_ids<char, unsigned char, double>();
 
+            SECTION("get")
+            {
+                static_assert(!matter::is_typed_id_v<char>);
+                static_assert(matter::is_typed_id_v<static_typed_id<char>>);
+
+                unordered1.template get<char>();
+                static_assert(
+                    std::is_same_v<decltype(unordered1.template get<0>()),
+                                   decltype(unordered1.template get<char>())>);
+                static_assert(
+                    std::is_same_v<decltype(unordered2.template get<1>()),
+                                   decltype(unordered2.template get<char>())>);
+            }
+
             SECTION("structured bindings")
             {
                 SECTION("unordered")


### PR DESCRIPTION
This allow components to be removed from entities, additionally erase was changed to use swap and pop. Further improvements to detaching components would be to eliminate the allocation of the vector to store the sorted ids. This could be done with a per `group_vector` buffer which only needs to be allocated once.