### PR TITLE
Remove the iterator and replace with group_view_iterator as iterator

### DIFF
--- a/include/matter/component/registry_view.hpp
+++ b/include/matter/component/registry_view.hpp
@@ -37,176 +37,6 @@ struct registry_view<matter::unordered_typed_ids<Id, TIds...>>
         using group_vector_view_sentinel_type =
             matter::sentinel_t<group_vector_view_type>;
 
-        using group_view_type = matter::group_view<typename TIds::type...>;
-        using group_view_iterator_type = matter::iterator_t<group_view_type>;
-        using group_view_sentinel_type = matter::sentinel_t<group_view_type>;
-
-        using value_type = matter::component_view<typename TIds::type...>;
-        using reference  = value_type;
-        using pointer    = void;
-        using iterator_category = std::forward_iterator_tag;
-        using difference_type   = typename std::iterator_traits<
-            matter::iterator_t<group_view_type>>::difference_type;
-
-    private:
-        unordered_ids_type ids_;
-
-        group_vector_container_iterator_type grp_vec_container_it_;
-        group_vector_container_sentinel_type grp_vec_container_sent_;
-
-        group_vector_view_iterator_type grp_vec_view_it_;
-        group_vector_view_sentinel_type grp_vec_view_sent_;
-
-        group_view_iterator_type grp_view_it_;
-        group_view_sentinel_type grp_view_sent_;
-
-    public:
-        constexpr iterator(
-            const unordered_ids_type&            ids,
-            group_vector_container_iterator_type begin_range,
-            group_vector_container_sentinel_type end_range) noexcept
-            : ids_{ids}, grp_vec_container_it_{begin_range + std::size(ids)},
-              grp_vec_container_sent_{end_range}, grp_vec_view_it_{},
-              grp_vec_view_sent_{}, grp_view_it_{}, grp_view_sent_{}
-        {
-            grp_vec_container_it_   = begin_range + std::size(ids);
-            grp_vec_container_sent_ = end_range;
-
-            for (; grp_vec_container_it_ < grp_vec_container_sent_;
-                 ++grp_vec_container_it_)
-            {
-                auto grp_vec_view =
-                    group_vector_view_type{ids_, *grp_vec_container_it_};
-
-                grp_vec_view_it_   = grp_vec_view.begin();
-                grp_vec_view_sent_ = grp_vec_view.end();
-                for (; grp_vec_view_it_ != grp_vec_view_sent_;
-                     ++grp_vec_view_it_)
-                {
-                    auto grp_view = *grp_vec_view_it_;
-
-                    grp_view_it_   = grp_view.begin();
-                    grp_view_sent_ = grp_view.end();
-                    for (; grp_view_it_ != grp_view_sent_; ++grp_view_it_)
-                    {
-                        // simply iterate until we get to our first valid
-                        // component_view, return afterwards as we're now in a
-                        // valid state
-                        return;
-                    }
-                }
-            }
-        }
-
-        constexpr iterator& operator++() noexcept
-        {
-            // if we hit the end of our current group
-            // we need to find our next group to view
-            if (++grp_view_it_ == grp_view_sent_)
-            {
-                do
-                {
-                    // if our current group_vector is at the end of valid groups
-                    // of this size we need to go to the next group_vector
-                    if (++grp_vec_view_it_ == grp_vec_view_sent_)
-                    {
-                        do
-                        {
-                            // if our next container iterator is larger than the
-                            // sentinel it means we've exhausted our group
-                            // vectors and are now officialy in the end state
-                            if (++grp_vec_container_it_ ==
-                                grp_vec_container_sent_)
-                            {
-                                // end state, do nothing
-                                return *this;
-                            }
-                            else
-                            {
-                                auto grp_vec_view = group_vector_view_type{
-                                    ids_, *grp_vec_container_it_};
-                                grp_vec_view_it_   = grp_vec_view.begin();
-                                grp_vec_view_sent_ = grp_vec_view.end();
-                            }
-                            // keep incrementing if there are no valid groups of
-                            // the specified size found
-                        } while (grp_vec_view_it_ == grp_vec_view_sent_);
-                    }
-                    else
-                    {
-                        auto grp_view  = *grp_vec_view_it_;
-                        grp_view_it_   = grp_view.begin();
-                        grp_view_sent_ = grp_view.end();
-                    }
-
-                    // skip over any empty groups
-                } while (grp_view_it_ == grp_view_sent_);
-            }
-
-            return *this;
-        }
-
-        constexpr iterator operator++(int) noexcept
-        {
-            auto it = *this;
-            ++(*this);
-            return it;
-        }
-
-        constexpr reference operator*() const noexcept
-        {
-            return *grp_view_it_;
-        }
-
-        constexpr auto is_beyond_end() const noexcept
-        {
-            return grp_vec_container_it_ >= grp_vec_container_sent_;
-        }
-    };
-
-    struct sentinel
-    {
-        constexpr sentinel() noexcept = default;
-
-        constexpr auto operator==(const iterator& it) const noexcept
-        {
-            return it.is_beyond_end();
-        }
-
-        constexpr auto operator!=(const iterator& it) const noexcept
-        {
-            return !(*this == it);
-        }
-
-        constexpr friend auto operator==(const iterator& it,
-                                         const sentinel&) noexcept
-        {
-            return it.is_beyond_end();
-        }
-
-        constexpr friend auto operator!=(const iterator& it,
-                                         const sentinel& sent) noexcept
-        {
-            return !(sent == it);
-        }
-    };
-
-    struct group_view_iterator
-    {
-        using group_vector_container_type = std::vector<group_vector>;
-        using group_vector_container_iterator_type =
-            matter::iterator_t<group_vector_container_type>;
-        using group_vector_container_sentinel_type =
-            matter::sentinel_t<group_vector_container_type>;
-
-        using group_vector_view_type = decltype(matter::group_vector_view{
-            std::declval<unordered_ids_type>(),
-            *std::declval<group_vector_container_iterator_type>()});
-        using group_vector_view_iterator_type =
-            matter::iterator_t<group_vector_view_type>;
-        using group_vector_view_sentinel_type =
-            matter::sentinel_t<group_vector_view_type>;
-
         using value_type        = group_view<typename TIds::type...>;
         using reference         = value_type;
         using pointer           = void;
@@ -220,7 +50,7 @@ struct registry_view<matter::unordered_typed_ids<Id, TIds...>>
         group_vector_view_sentinel_type grp_vec_view_sent_;
 
     public:
-        constexpr group_view_iterator(
+        constexpr iterator(
             const unordered_ids_type&            ids,
             group_vector_container_iterator_type begin_range,
             group_vector_container_sentinel_type end_range) noexcept
@@ -255,7 +85,7 @@ struct registry_view<matter::unordered_typed_ids<Id, TIds...>>
             }
         }
 
-        constexpr group_view_iterator& operator++() noexcept
+        constexpr iterator& operator++() noexcept
         {
             // we hit the end of our current group_vector_view, let's move up
             if (++grp_vec_view_it_ == grp_vec_view_sent_)
@@ -301,32 +131,30 @@ struct registry_view<matter::unordered_typed_ids<Id, TIds...>>
         }
     };
 
-    struct group_view_sentinel
+    struct sentinel
     {
-        constexpr group_view_sentinel() noexcept = default;
+        constexpr sentinel() noexcept = default;
 
-        constexpr auto operator==(const group_view_iterator& it) const noexcept
+        constexpr auto operator==(const iterator& it) const noexcept
         {
             // use >= over == because the begin can be higher than end on
             // instantiation
             return it.is_beyond_end();
         }
 
-        constexpr auto operator!=(const group_view_iterator& it) const noexcept
+        constexpr auto operator!=(const iterator& it) const noexcept
         {
             return !(*this == it);
         }
 
-        constexpr friend auto
-        operator==(const group_view_iterator& it,
-                   const group_view_sentinel& sent) noexcept
+        constexpr friend auto operator==(const iterator& it,
+                                         const sentinel& sent) noexcept
         {
             return sent == it;
         }
 
-        constexpr friend auto
-        operator!=(const group_view_iterator& it,
-                   const group_view_sentinel& sent) noexcept
+        constexpr friend auto operator!=(const iterator& it,
+                                         const sentinel& sent) noexcept
         {
             return sent != it;
         }
@@ -350,19 +178,9 @@ public:
         return iterator{ids_, begin_, end_};
     }
 
-    constexpr sentinel end() const noexcept
+    constexpr sentinel end() noexcept
     {
         return sentinel{};
-    }
-
-    constexpr group_view_iterator group_view_begin() noexcept
-    {
-        return group_view_iterator{ids_, begin_, end_};
-    }
-
-    constexpr group_view_sentinel group_view_end() noexcept
-    {
-        return group_view_sentinel{};
     }
 
     template<typename Function>
@@ -394,7 +212,7 @@ public:
 
     /// erase the entity at index idx of group at it, all components will be
     /// removed with the entity
-    void erase(const group_view_iterator& it, std::size_t idx) noexcept
+    void erase(const iterator& it, std::size_t idx) noexcept
     {
         // this is where the to be erased entity lies
         auto any_grp = (*it).underlying_group();
@@ -406,7 +224,7 @@ public:
     template<typename... Cs>
     std::enable_if_t<(detail::type_in_list_v<Cs, typename TIds::type...> &&
                       ...)>
-    detach(const group_view_iterator& it, std::size_t idx) noexcept
+    detach(const iterator& it, std::size_t idx) noexcept
     {
         any_group current_group     = (*it).underlying_group();
         auto      group_size        = current_group.group_size();

--- a/test/test_registry.cpp
+++ b/test/test_registry.cpp
@@ -145,19 +145,27 @@ TEST_CASE("registry")
                     // auto sent = fview.end();
                     auto j1 = 0;
                     matter::for_each(
-                        fview.begin(), fview.end(), [&](auto&& comp_view) {
-                            comp_view.invoke([&](float_comp& fcomp) {
-                                CHECK(fcomp.f == j1);
-                                fcomp.f = (2 * j1);
-                                ++j1;
-                            });
+                        fview.begin(), fview.end(), [&](auto&& group_view) {
+                            for (std::size_t i = 0; i < group_view.size(); ++i)
+                            {
+                                auto comp_view = group_view[i];
+                                comp_view.invoke([&](float_comp& fcomp) {
+                                    CHECK(fcomp.f == j1);
+                                    fcomp.f = (2 * j1);
+                                    ++j1;
+                                });
+                            }
                         });
                     j1 = 0;
                     matter::for_each(
-                        fview.begin(), fview.end(), [&](auto&& comp_view) {
-                            auto [fcomp] = comp_view;
-                            CHECK(fcomp.f == (2 * j1));
-                            ++j1;
+                        fview.begin(), fview.end(), [&](auto&& group_view) {
+                            for (std::size_t i = 0; i < group_view.size(); ++i)
+                            {
+                                auto comp_view = group_view[i];
+                                auto [fcomp]   = comp_view;
+                                CHECK(fcomp.f == (2 * j1));
+                                ++j1;
+                            }
                         });
                 }
             }
@@ -211,8 +219,8 @@ TEST_CASE("registry")
 
         SECTION("erase")
         {
-            auto it = iview.group_view_begin();
-            CHECK(it != iview.group_view_end());
+            auto it = iview.begin();
+            CHECK(it != iview.end());
             // should be at index 0 within the group
             iview.erase(it, 0);
 
@@ -226,7 +234,7 @@ TEST_CASE("registry")
             // the only inct_comp should be gone
             CHECK(n == 0);
 
-            auto it1 = fview.group_view_begin();
+            auto it1 = fview.begin();
             // erase through the registry method
             reg.erase(it1, 0);
 
@@ -242,13 +250,13 @@ TEST_CASE("registry")
 
         SECTION("detach")
         {
-            auto it = iview.group_view_begin();
+            auto it = iview.begin();
             iview.detach<int_comp>(it, 0);
 
             // views need to be reconstructed after modification
             iview = reg.view<int_comp>();
             n     = 0;
-            it    = iview.group_view_begin();
+            it    = iview.begin();
             iview.for_each([&](auto&&...) { ++n; });
             CHECK(n == 0);
 
@@ -292,7 +300,7 @@ TEST_CASE("registry")
             fiview.for_each([&](auto&&...) { ++n; });
             CHECK(n == 10000);
 
-            fiview.detach<float_comp>(fiview.group_view_begin(), 0);
+            fiview.detach<float_comp>(fiview.begin(), 0);
 
             auto icview = detach_reg.view<int_comp>();
 


### PR DESCRIPTION
Since the old iterator was embarrassingly slow, it is now replaced with an iterator that gives us access to `group_views`. these `group_views` can then be iterated through index or whichever favorite method.