### PR TITLE
Simplify the meta access trait

### DIFF
--- a/include/matter/access/prototype.hpp
+++ b/include/matter/access/prototype.hpp
@@ -28,10 +28,6 @@ struct meta_access
 
     constexpr meta_access(registry_type&);
 
-    constexpr void process_group_vector(matter::group_vector<id_type>&);
-
-    constexpr void process_group(matter::any_group<id_type>);
-
     constexpr void make_access(matter::entity_handle<id_type>);
 };
 
@@ -44,12 +40,8 @@ struct meta_access_other
 
     constexpr meta_access_other(registry_type&);
 
-    constexpr std::optional<float>
-    process_group_vector(matter::group_vector<id_type>&);
-
     // take any group and the derefed result of process_group_vector if not void
-    constexpr std::optional<char> process_group(matter::any_group<id_type>,
-                                                float);
+    constexpr std::optional<char> process_group(matter::any_group<id_type>);
 
     // this function gets the handle, the dereferenced return value of
     // process_group, or process_group_vector if process_group function is not
@@ -57,15 +49,18 @@ struct meta_access_other
     // required_types.
     // required_types is also used in filtering groups for presence.
     constexpr matter::prototype::access
-    make_access(matter::entity_handle<id_type>, char, int&);
+    make_access(matter::entity_handle<id_type>,
+                char,
+                matter::storage_handle<id_type, int>);
 };
 
 static_assert(
-    matter::is_access_v<matter::prototype::access, matter::registry<>>);
-static_assert(matter::is_meta_access_v<
-              matter::prototype::meta_access<matter::registry<>>>);
-static_assert(matter::is_meta_access_v<
-              matter::prototype::meta_access_other<matter::registry<>>>);
+    matter::is_access_v<matter::prototype::access,
+                        matter::registry<matter::unsigned_id<std::size_t>>>);
+static_assert(matter::is_meta_access_v<matter::prototype::meta_access<
+                  matter::registry<matter::unsigned_id<std::size_t>>>>);
+static_assert(matter::is_meta_access_v<matter::prototype::meta_access_other<
+                  matter::registry<matter::unsigned_id<std::size_t>>>>);
 } // namespace prototype
 } // namespace matter
 

--- a/include/matter/access/read.hpp
+++ b/include/matter/access/read.hpp
@@ -43,13 +43,6 @@ public:
     constexpr read_meta(registry_type&) noexcept
     {}
 
-    constexpr void process_group_vector(matter::group_vector<id_type>&) const
-        noexcept
-    {}
-
-    constexpr void process_group(const_any_group<id_type>) const noexcept
-    {}
-
     constexpr read<C>
     make_access(matter::entity_handle<id_type>     ent,
                 matter::storage_handle<id_type, C> component) noexcept
@@ -58,7 +51,7 @@ public:
     }
 
     // there are no commands to produce
-    constexpr void make_commands(read<C>&& r) const noexcept
+    constexpr void make_commands(read<C>&&) const noexcept
     {
         return;
     }

--- a/include/matter/access/write.hpp
+++ b/include/matter/access/write.hpp
@@ -49,13 +49,6 @@ public:
     constexpr write_meta(registry_type&) noexcept
     {}
 
-    constexpr void process_group_vector(matter::group_vector<id_type>&) const
-        noexcept
-    {}
-
-    constexpr void process_group(const_any_group<id_type>) const noexcept
-    {}
-
     constexpr write<C> make_access(matter::entity_handle<id_type>,
                                    matter::storage_handle<id_type, C>) const
         noexcept


### PR DESCRIPTION
Processing the `group_vector` is no longer required and the presence
even if empty of the `process_group` function is also no longer required.

The rationale for removing the `group_vector` processing is that this is a too low level
property to expose to the users, they need not not be aware of more than the groups.