### PR TITLE
Retrieve a range of groups from `group_container`

### DIFF
--- a/include/matter/component/any_group.hpp
+++ b/include/matter/component/any_group.hpp
@@ -500,10 +500,8 @@ public:
     }
 
     template<typename T>
-    constexpr
-
-        const matter::component_storage_t<T>&
-        storage(const matter::typed_id<id_type, T>& tid) const noexcept
+    constexpr const matter::component_storage_t<T>&
+    storage(const matter::typed_id<id_type, T>& tid) const noexcept
     {
         assert(contains(tid));
 

--- a/include/matter/component/group_container.hpp
+++ b/include/matter/component/group_container.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <range/v3/view/all.hpp>
+
 #include "matter/component/any_group.hpp"
 #include "matter/component/group.hpp"
 #include "matter/component/typed_id.hpp"
@@ -342,6 +344,13 @@ private:
     // stored in index = 0.
     std::vector<std::size_t> begin_indices_;
 
+    // stores views to all groups managed by this group_container.
+    // This cache is required to allow efficient iteration over all groups in
+    // the container. Iterating otherwise would require conditional checks on
+    // each increment of the iterator because we don't know when the group_size
+    // might change.
+    std::vector<matter::any_group<id_type>> view_cache_;
+
 public:
     group_container() noexcept = default;
 
@@ -375,6 +384,11 @@ public:
     constexpr std::size_t groups_size() const noexcept
     {
         return begin_indices_.size();
+    }
+
+    constexpr auto range() noexcept
+    {
+        return ranges::view::all(view_cache_);
     }
 
     constexpr sized_group_range<id_type> range(std::size_t grp_size) noexcept
@@ -596,6 +610,8 @@ private:
         // increment all following index values
         increment_indices(grp_size);
 
+        view_cache_.push_back({*new_pos, grp_size});
+
         // return where the inserted element is at
         return {new_pos, grp_size};
     }
@@ -651,7 +667,7 @@ private:
             }
         }
 
-	// verify we have all the elements in our buffer
+        // verify we have all the elements in our buffer
         assert(stores_buffer_.size() == grp_size);
 
         auto move_beg = stores_buffer_.begin();

--- a/include/matter/component/group_container.hpp
+++ b/include/matter/component/group_container.hpp
@@ -566,6 +566,7 @@ private:
 
     {
         constexpr auto grp_size = sizeof...(Ts);
+        assert(pos.group_size() == grp_size);
 
         // assert that the ids don't already exist
         // and the element at the position is greater than our ids.
@@ -604,6 +605,7 @@ private:
             const matter::const_any_group<id_type>     storage_source,
             const matter::ordered_untyped_ids<id_type> copy_ids) noexcept
     {
+        assert(pos.group_size() == copy_ids.size());
         assert(stores_buffer_.empty());
         assert(storage_source.contains(copy_ids));
         assert([&] {

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,8 @@ matter_inc = include_directories('include')
 
 omp_dep = dependency('openmp')
 
+range_v3_dep = dependency('range', fallback: ['range-v3', 'range_dep'])
+
 if get_option('build_tests')
     catch2_dep = dependency('catch2', fallback: ['catch2', 'catch2_dep'])
 endif
@@ -23,7 +25,7 @@ endif
 
 matter = declare_dependency(
   include_directories: matter_inc,
-  dependencies: [omp_dep],
+  dependencies: [omp_dep, range_v3_dep],
 )
 
 if get_option('build_tests')

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,3 +1,4 @@
 packagecache/
 Catch2-*/
 benchmark-*/
+range-v3-*/

--- a/subprojects/range-v3.wrap
+++ b/subprojects/range-v3.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = range-v3-0.3.6
+source_url = https://github.com/ericniebler/range-v3/archive/0.3.6.zip
+source_filename = range-v3-0.3.6.zip
+source_hash = 42cafd42fd51555844eb129018188f4cc7d9a60cbcc1fcb98496cd8942e5fadf
+
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/range-v3/0.3.6/1/get_zip
+patch_filename = range-v3-0.3.6-1-wrap.zip
+patch_hash = 1dea6165a0549b2a0633a89d3e07ac822c9adbb3399427aec583d9ab90c909ff

--- a/test/test_group_container.cpp
+++ b/test/test_group_container.cpp
@@ -17,12 +17,16 @@ TEST_CASE("group_container")
     // fill up with groups
     cont.try_emplace(ident.ids<char>());
 
+    CHECK(1 == cont.range().size());
     CHECK(1 == cont.size());
     cont.try_emplace(ident.ids<float>());
+    CHECK(2 == cont.range().size());
     CHECK(2 == cont.size());
     cont.try_emplace_group(ident.ids<int, float, char, double>());
+    CHECK(3 == cont.range().size());
     CHECK(6 == cont.size());
     cont.try_emplace_group(ident.ids<float>()); // is already inserted
+    CHECK(3 == cont.range().size());
     CHECK(6 == cont.size());
 
     auto ordered_typed   = ident.ordered_ids<int, float, char>();


### PR DESCRIPTION
A range of groups is required to more easily apply filters for access specifiers and to allow multiple layers of `group_container`.