### PR TITLE
group_slice is a subset of a group

### DIFF
--- a/include/matter/component/component_view.hpp
+++ b/include/matter/component/component_view.hpp
@@ -10,7 +10,7 @@ namespace matter
 template<typename... Cs>
 struct component_view
 {
-    static_assert((matter::is_component_v<Cs> && ...),
+    static_assert((matter::is_component_v<std::remove_const_t<Cs>> && ...),
                   "One of the Cs... is not a valid component");
 
 private:

--- a/include/matter/component/group.hpp
+++ b/include/matter/component/group.hpp
@@ -10,312 +10,89 @@
 
 #include "matter/component/any_group.hpp"
 #include "matter/component/component_view.hpp"
+#include "matter/component/group_slice.hpp"
 #include "matter/component/insert_buffer.hpp"
 #include "matter/component/traits.hpp"
 #include "matter/component/typed_id.hpp"
+#include "matter/storage/erased_storage.hpp"
 #include "matter/util/container.hpp"
 #include "matter/util/id_erased.hpp"
 
 namespace matter
 {
 template<typename Id, typename... Cs>
-class group {
+class group : public matter::group_slice<Id, Cs...> {
+    using base_ = matter::group_slice<Id, Cs...>;
+
 public:
     using id_type = Id;
 
-public:
-    struct iterator
-    {
-        using value_type        = matter::component_view<Cs...>;
-        using reference         = matter::component_view<Cs...>;
-        using pointer           = void;
-        using difference_type   = std::ptrdiff_t;
-        using iterator_category = std::random_access_iterator_tag;
-
-    private:
-        std::tuple<typename matter::component_storage_t<Cs>::iterator...> its_;
-
-    public:
-        constexpr iterator(
-            typename matter::component_storage_t<Cs>::iterator... its)
-            : its_{its...}
-        {}
-
-        constexpr auto operator==(const iterator& other) const noexcept
-        {
-            return first_it() == other.first_it();
-        }
-
-        constexpr auto operator!=(const iterator& other) const noexcept
-        {
-            return !(*this == other);
-        }
-
-        constexpr iterator& operator++() noexcept
-        {
-            std::apply([](auto&... its) { (++its, ...); });
-            return *this;
-        }
-
-        constexpr iterator& operator--() noexcept
-        {
-            std::apply([](auto&... its) { (--its, ...); });
-            return *this;
-        }
-
-        constexpr iterator operator++(int) noexcept
-        {
-            auto it = *this;
-            ++(*this);
-            return it;
-        }
-
-        constexpr iterator operator--(int) noexcept
-        {
-            auto it = *this;
-            --(*this);
-            return it;
-        }
-
-        constexpr iterator& operator+=(difference_type movement) noexcept
-        {
-            std::apply(
-                [movement](auto&... its) { (its.operator+=(movement), ...); },
-                its_);
-
-            return *this;
-        }
-
-        constexpr iterator& operator-=(difference_type movement) noexcept
-        {
-            std::apply(
-                [movement](auto&... its) { (its.operator-=(movement), ...); },
-                its_);
-
-            return *this;
-        }
-
-        constexpr iterator operator+(difference_type movement) const noexcept
-        {
-            auto it = *this;
-            it += movement;
-            return it;
-        }
-
-        constexpr iterator operator-(difference_type movement) const noexcept
-        {
-            auto it = *this;
-            it -= movement;
-            return it;
-        }
-
-        constexpr reference operator*() noexcept
-        {
-            return std::apply(
-                [](auto&&... its) { return matter::component_view{*its...}; },
-                its_);
-        }
-
-        constexpr const reference operator*() const noexcept
-        {
-            return std::apply(
-                [](auto&&... its) { return matter::component_view{*its...}; },
-                its_);
-        }
-
-        template<typename C>
-        std::enable_if_t<detail::type_in_list_v<C, Cs...>,
-                         typename matter::component_storage_t<C>::iterator>
-        get() const noexcept
-        {
-            return std::get<typename matter::component_storage_t<C>::iterator>(
-                its_);
-        }
-
-        template<std::size_t N>
-        auto get() const noexcept
-        {
-            return std::get<N>(its_);
-        }
-
-    private:
-        constexpr auto first_it() const noexcept
-        {
-            return std::get<0>(its_);
-        }
-    };
-
-    using reverse_iterator = std::reverse_iterator<iterator>;
-
-    template<typename _Id, typename... Ts>
-    friend class group_view;
+    using iterator = typename base_::iterator;
 
     template<typename _Id, typename... Ts>
     friend class group;
 
-private:
-    matter::erased_storage<id_type>* underlying_storage_;
-    std::tuple<std::reference_wrapper<matter::component_storage_t<Cs>>...>
-        stores_;
+protected:
+    explicit constexpr group(
+        matter::component_storage_t<Cs>&... stores) noexcept
+        : base_{stores...}
+    {}
 
 public:
-    template<typename... Ts>
-    constexpr group(
-        const matter::unordered_typed_ids<id_type, Ts...>& unordered,
-        any_group<id_type>                                 grp) noexcept
-        : underlying_storage_{grp.data()}, stores_{grp.storage(unordered)}
+    explicit constexpr group(
+        matter::any_group<id_type>                         grp,
+        const matter::unordered_typed_ids<id_type, Cs...>& ids) noexcept
+        : base_{grp, ids}
+    {}
+
+    template<typename... Us>
+    constexpr group(const matter::group<id_type, Us...>& other) noexcept
+        : base_{other}
+    {}
+
+    template<typename... Us>
+    constexpr group&
+    operator=(const matter::group<id_type, Us...>& other) noexcept
     {
-        // require exact match and not just contains being satisfied
-        assert(grp == matter::ordered_typed_ids{unordered});
+        *static_cast<base_>(this) = other;
+        return *this;
     }
 
-    template<typename... OtherCs>
-    constexpr group(const matter::group<id_type, OtherCs...>& other) noexcept
-        : underlying_storage_{other.underlying_storage_},
-          stores_{
-              std::get<std::reference_wrapper<matter::component_storage_t<Cs>>>(
-                  other.stores_)...}
-    {
-        static_assert(sizeof...(OtherCs) == sizeof...(Cs),
-                      "Groups are required to be of equal size");
-        static_assert((detail::type_in_list_v<OtherCs, Cs...> && ...),
-                      "Incompatible components, cannot construct");
-    }
+    /*
+      constexpr iterator erase(iterator pos) noexcept
+      {
+          std::apply(
+              [&](auto... stores) {
+                  (stores.erase(pos.template get<Cs>()), ...);
+              },
+              stores_);
+      }
+    */
 
-    constexpr any_group<id_type> underlying_group() const noexcept
+    template<typename... Args>
+    constexpr matter::component_view<Cs...>
+    emplace_back(Args&&... args) noexcept
     {
-        return any_group<id_type>{underlying_storage_, group_size()};
-    }
-
-    constexpr auto operator==(const group&) const noexcept
-    {
-        // there can only ever be one group of a certain type in existence
-        return true;
-    }
-
-    constexpr auto operator!=(const group& other) const noexcept
-    {
-        return !(*this == other);
-    }
-
-    template<typename T>
-    constexpr auto contains() const noexcept
-    {
-        return detail::type_in_list_v<T, Cs...>;
-    }
-
-    template<typename T>
-    constexpr bool contains(const matter::typed_id<id_type, T>&) const noexcept
-    {
-        return contains<T>();
-    }
-
-    template<typename... Ts>
-    constexpr auto
-    contains(const matter::unordered_typed_ids<id_type, Ts...>&) const noexcept
-    {
-        return (contains<Ts>() && ...);
-    }
-
-    template<typename... Ts>
-    constexpr auto
-    contains(const matter::ordered_typed_ids<id_type, Ts...>&) const noexcept
-    {
-        return (contains<Ts>() && ...);
-    }
-
-    constexpr iterator begin() noexcept
-    {
-        return std::apply(
-            [](auto... stores) { return iterator{stores.get().begin()...}; },
-            stores_);
-    }
-
-    constexpr iterator end() noexcept
-    {
-        return std::apply(
-            [](auto... stores) { return iterator{stores.get().end()...}; },
-            stores_);
-    }
-
-    constexpr iterator erase(iterator pos) noexcept
-    {
+        static_assert(sizeof...(Args) == sizeof...(Cs),
+                      "Must pass constructor argument for each component");
         std::apply(
-            [&](auto... stores) {
-                (stores.erase(pos.template get<Cs>()), ...);
-            },
-            stores_);
-    }
-
-    template<std::size_t... Is, typename TCArgs>
-    constexpr component_view<Cs...>
-    _emplace_back_impl(std::index_sequence<Is...>, TCArgs&& cargs)
-    {
-        std::apply(
-            [&](auto... stores) {
-                (matter::emplace_back_tuple(
-                     stores.get(), std::get<Is>(std::forward<TCArgs>(cargs))),
+            [&](auto&&... stores) {
+                (matter::detail::emplace_back_ambiguous(
+                     stores.get(), std::forward<Args>(args)),
                  ...);
             },
-            stores_);
+            this->stores_);
 
-        return back();
+        return this->back();
     }
 
-    // emplace_back function which takes tuples as arguments
-    template<typename... CArgs>
-    constexpr std::enable_if_t<
-        (matter::detail::is_constructible_expand_tuple_v<Cs, CArgs> && ...),
-        component_view<Cs...>>
-    emplace_back(CArgs&&... cargs) noexcept(
-        (detail::is_nothrow_constructible_expand_tuple_v<Cs, CArgs> && ...))
-    {
-        return _emplace_back_impl(
-            std::index_sequence_for<Cs...>{},
-            std::make_tuple(std::forward<CArgs>(cargs)...));
-    }
-
-    template<typename... Ts>
-    constexpr std::enable_if_t<(std::is_constructible_v<Cs, Ts> && ...),
-                               component_view<Cs...>>
-    emplace_back(Ts&&... ts) noexcept(
-        (std::is_nothrow_constructible_v<Cs, Ts> && ...))
+    void reserve(std::size_t new_capacity) noexcept
     {
         std::apply(
             [&](auto&&... stores) {
-                (stores.get().emplace_back(std::forward<Ts>(ts)), ...);
+                (stores.get().reserve(new_capacity), ...);
             },
-            stores_);
-
-        return back();
-    }
-
-    // emplace_back function for when there is a single component in the group
-    template<typename... Args>
-    constexpr std::enable_if_t<
-        sizeof...(Cs) == 1 &&
-            std::is_constructible_v<matter::detail::first_t<Cs...>, Args...>,
-        component_view<Cs...>>
-    emplace_back(Args&&... args) noexcept(
-        std::is_nothrow_constructible_v<matter::detail::first_t<Cs...>,
-                                        Args...>)
-    {
-        std::apply(
-            [&](auto&& store) {
-                // should work since only a single store
-                store.get().emplace_back(std::forward<Args>(args)...);
-            },
-            stores_);
-    }
-
-    constexpr component_view<Cs...> push_back(const Cs&... comps)
-    {
-        return emplace_back(std::forward_as_tuple(comps)...);
-    }
-
-    constexpr component_view<Cs...> push_back(Cs&&... comps)
-    {
-        return emplace_back(std::forward_as_tuple(std::move(comps))...);
+            this->stores_);
     }
 
     template<typename... Ts>
@@ -327,58 +104,51 @@ public:
              decltype(*std::make_move_iterator(buffer.template begin<Cs>()))> &&
          ...))
     {
-        return iterator{get<Cs>().insert(
-            get<Cs>().end(),
-            std::make_move_iterator(buffer.template begin<Cs>()),
-            std::make_move_iterator(buffer.template end<Cs>()))...};
+        auto pos = this->size();
+
+        (this->template get<Cs>().insert(
+             this->template get<Cs>().end(),
+             std::make_move_iterator(buffer.template begin<Cs>()),
+             std::make_move_iterator(buffer.template end<Cs>())),
+         ...);
+
+        return iterator{pos, this->template get<Cs>()...};
     }
 
-    constexpr component_view<Cs...> back() noexcept
-    {
-        return component_view{get<Cs>().back()...};
-    }
-
-    static constexpr std::size_t group_size() noexcept
+    constexpr std::size_t group_size() const noexcept
     {
         return sizeof...(Cs);
     }
 
-    constexpr std::size_t size() const noexcept
-    {
-        return std::get<0>(stores_).get().size();
-    }
-
-    constexpr auto empty() const noexcept
-    {
-        return std::get<0>(stores_).get().empty();
-    }
-
-    constexpr matter::component_view<Cs...> operator[](std::size_t i) noexcept
-    {
-        return {get<Cs>()[i]...};
-    }
-
-private:
-    template<typename T>
-    constexpr auto& get() noexcept
-    {
-        return std::get<std::reference_wrapper<matter::component_storage_t<T>>>(
-                   stores_)
-            .get();
-    }
-
-    template<typename T>
-    constexpr const auto& get() const noexcept
-    {
-        return std::get<std::reference_wrapper<matter::component_storage_t<T>>>(
-                   stores_)
-            .get();
-    }
+    template<typename _Id, typename... _Cs>
+    friend constexpr std::optional<matter::group<_Id, _Cs...>>
+    make_group(matter::any_group<_Id>                          grp,
+               const matter::unordered_typed_ids<_Id, _Cs...>& ids) noexcept;
 };
 
-template<typename Id, typename... Ts>
-group(const matter::unordered_typed_ids<Id, Ts...>&,
-      any_group<Id>) noexcept->group<Id, Ts...>;
+template<typename Id, typename... Cs>
+constexpr std::optional<matter::group<Id, Cs...>>
+make_group(matter::any_group<Id>                         grp,
+           const matter::unordered_typed_ids<Id, Cs...>& ids) noexcept
+{
+    if (grp.group_size() != ids.size())
+    {
+        return std::nullopt;
+    }
+
+    auto opt_stores = grp.maybe_storage(ids);
+
+    if (opt_stores)
+    {
+        return std::apply(
+            [](auto&... stores) { return matter::group<Id, Cs...>{stores...}; },
+            *opt_stores);
+    }
+    else
+    {
+        return std::nullopt;
+    }
+}
 
 } // namespace matter
 

--- a/include/matter/component/group_container.hpp
+++ b/include/matter/component/group_container.hpp
@@ -427,10 +427,10 @@ public:
 
         if (it != rng.end())
         {
-            return matter::group{ids, *it};
+            return matter::group{*it, ids};
         }
 
-        return {};
+        return std::nullopt;
     }
 
     template<typename... Ts>
@@ -553,7 +553,7 @@ public:
         const matter::ordered_typed_ids<id_type, Ts...>&   ordered_ids) noexcept
     {
         auto it = try_emplace(ids, ordered_ids);
-        return matter::group{ids, *it};
+        return matter::group{*it, ids};
     }
 
     /// \sa same as try_emplace but will construct ordered_ids from the

--- a/include/matter/component/group_slice.hpp
+++ b/include/matter/component/group_slice.hpp
@@ -1,0 +1,428 @@
+#ifndef MATTER_COMPONENT_SUBGROUP_HPP
+#define MATTER_COMPONENT_SUBGROUP_HPP
+
+#pragma once
+
+#include "matter/component/any_group.hpp"
+#include "matter/component/component_view.hpp"
+#include "matter/component/traits.hpp"
+#include "matter/component/typed_id.hpp"
+
+namespace matter
+{
+/// extracts a subset of a group.
+/// The passed types can be marked as const to be read only.
+/// implements the entire interface required by the storage concept.
+template<typename Id, typename... Ts>
+class group_slice {
+    static_assert(sizeof...(Ts) >= 1, "Need at least one component storage");
+
+    template<typename _Id, typename... Us>
+    friend class group_slice;
+
+public:
+    using id_type = Id;
+
+    /// This is an iterator for the subgroup.
+    /// Unlike regular iterators this uses a reference to the storage and index
+    /// to iterate over the stores. The reason for this is that this makes it
+    /// easier to implement some kinds of stores such as a pool with chunks that
+    /// might otherwise have to check for the end of the chunk on each
+    /// increment.
+    /// Stores should mostly be contiguous data structures so index iteration
+    /// should in all cases be available and be ass efficient if not more
+    /// efficient than iterator based iteration. Another major benefit is that
+    /// on reallocation of the underlying data structure these iterators don't
+    /// get invalidated.
+    class iterator {
+    public:
+        using value_type        = matter::component_view<Ts...>;
+        using reference         = value_type;
+        using pointer           = void;
+        using difference_type   = std::ptrdiff_t;
+        using iterator_category = std::random_access_iterator_tag;
+
+    private:
+        std::size_t idx_;
+        // must be pointer to make the type default constructible
+        // assume a precondition on each method for these to be non null.
+        std::tuple<matter::component_storage_t<Ts>*...> stores_;
+
+    public:
+        constexpr iterator() noexcept : idx_{0}, stores_{nullptr}
+        {}
+
+        constexpr iterator(std::size_t index,
+                           matter::component_storage_t<Ts>&... stores) noexcept
+            : idx_{index}, stores_{std::addressof(stores)...}
+        {}
+
+        constexpr bool operator==(const iterator& other) const noexcept
+        {
+            return idx_ == other.idx_ && stores_ == other.stores_;
+        }
+
+        constexpr bool operator!=(const iterator& other) const noexcept
+        {
+            return !(*this == other);
+        }
+
+        constexpr bool operator<(const iterator& other) const noexcept
+        {
+            return idx_ < other.idx_;
+        }
+
+        constexpr bool operator>(const iterator& other) const noexcept
+        {
+            return idx_ > other.idx_;
+        }
+
+        constexpr bool operator<=(const iterator& other) const noexcept
+        {
+            return idx_ <= other.idx_;
+        }
+
+        constexpr bool operator>=(const iterator& other) const noexcept
+        {
+            return idx_ >= other.idx_;
+        }
+
+        constexpr iterator& operator++() noexcept
+        {
+            assert(not_null());
+            ++idx_;
+            return *this;
+        }
+
+        constexpr iterator& operator--() noexcept
+        {
+            assert(not_null());
+            --idx_;
+            return *this;
+        }
+
+        constexpr iterator operator++(int) noexcept
+        {
+            assert(not_null());
+            auto ret = *this;
+            ++(*this);
+            return ret;
+        }
+
+        constexpr iterator operator--(int) noexcept
+        {
+            assert(not_null());
+            auto ret = *this;
+            --(*this);
+            return ret;
+        }
+
+        constexpr iterator& operator+=(difference_type movement) noexcept
+        {
+            assert(not_null());
+            idx_ += movement;
+            return *this;
+        }
+
+        constexpr iterator& operator-=(difference_type movement) noexcept
+        {
+            assert(not_null());
+            idx_ -= movement;
+            return *this;
+        }
+
+        constexpr iterator operator+(difference_type movement) const noexcept
+        {
+            assert(not_null());
+            auto ret = *this;
+            ret += movement;
+            return ret;
+        }
+
+        constexpr iterator operator-(difference_type movement) const noexcept
+        {
+            assert(not_null());
+            auto ret = *this;
+            ret -= movement;
+            return ret;
+        }
+
+        constexpr difference_type operator-(const iterator& it) const noexcept
+        {
+            assert(not_null());
+            return idx_ - it.idx_;
+        }
+
+        constexpr reference operator*() const noexcept
+        {
+            assert(not_null());
+            return std::apply(
+                [&](auto*... stores) { return reference{(*stores)[idx_]...}; },
+                stores_);
+        }
+
+    private:
+        constexpr bool not_null() const noexcept
+        {
+            return std::apply([](auto*... stores) { return (stores && ...); },
+                              stores_);
+        }
+    };
+
+protected:
+    std::tuple<std::reference_wrapper<matter::component_storage_t<Ts>>...>
+        stores_;
+
+protected:
+    constexpr group_slice(matter::component_storage_t<Ts>&... stores) noexcept
+        : stores_{stores...}
+    {}
+
+public:
+    constexpr group_slice(
+        matter::any_group<Id>                         grp,
+        const matter::unordered_typed_ids<Id, Ts...>& ids) noexcept
+        : group_slice{grp.storage(ids.template get<Ts>())...}
+    {
+        assert(grp.group_size() <= ids.size());
+        assert(grp.contains(matter::ordered_typed_ids{ids}));
+    }
+
+    template<typename... Us>
+    constexpr group_slice(
+        const matter::group_slice<id_type, Us...>& other) noexcept
+        : stores_{
+              std::get<std::reference_wrapper<matter::component_storage_t<Ts>>>(
+                  other.stores_)...}
+    {
+        static_assert(sizeof...(Ts) == sizeof...(Us),
+                      "Subgroups must be of equal size for conversion");
+        static_assert((matter::detail::type_in_list_v<Us, Ts...> && ...),
+                      "Incompatible types, cannot construct");
+    }
+
+    template<typename... Us>
+    constexpr std::enable_if_t<sizeof...(Ts) == sizeof...(Us) &&
+                                   (matter::detail::type_in_list_v<Us, Ts...> &&
+                                    ...),
+                               group_slice&>
+    operator=(const matter::group_slice<id_type, Us...>& other) noexcept
+    {
+        // use lambda to workaround the fold expression limitation
+        auto assign = [](auto& lhs, auto& rhs) { lhs = rhs; };
+
+        // reassign all reference wrappers
+        (assign(
+             std::get<std::reference_wrapper<matter::component_storage_t<Ts>>>(
+                 stores_),
+             std::get<std::reference_wrapper<matter::component_storage_t<Ts>>>(
+                 other.stores_)),
+         ...);
+
+        return *this;
+    }
+
+    template<typename... Us>
+    constexpr std::enable_if_t<sizeof...(Ts) == sizeof...(Us) &&
+                                   (matter::detail::type_in_list_v<Us, Ts...> &&
+                                    ...),
+                               bool>
+    operator==(const matter::group_slice<id_type, Us...>& other) const noexcept
+    {
+        // use a lambda to circumvent the limitations of fold expressions
+        auto comp = [](const auto& lhs, const auto& rhs) { return lhs == rhs; };
+        // check the address of each storage as they never get relocated in
+        // memory and therefore satisfies equality
+        return (
+            comp(std::addressof(std::get<std::reference_wrapper<
+                                    matter::component_storage_t<Ts>>>(stores_)
+                                    .get()),
+                 std::addressof(
+                     std::get<std::reference_wrapper<
+                         matter::component_storage_t<Ts>>>(other.stores_)
+                         .get())) &&
+            ...);
+    }
+
+    template<typename... Us>
+    constexpr std::enable_if_t<sizeof...(Ts) == sizeof...(Us) &&
+                                   (matter::detail::type_in_list_v<Us, Ts...> &&
+                                    ...),
+                               bool>
+    operator!=(const matter::group_slice<id_type, Us...>& other) const noexcept
+    {
+        return !(*this == other);
+    }
+
+    constexpr iterator begin() noexcept
+    {
+        return std::apply(
+            [](auto&&... stores) {
+                return iterator{0, stores.get()...};
+            },
+            stores_);
+    }
+
+    constexpr iterator end() noexcept
+    {
+        return std::apply(
+            [&](auto&&... stores) {
+                return iterator{size(), stores.get()...};
+            },
+            stores_);
+    }
+
+    constexpr std::size_t size() const noexcept
+    {
+        return std::size(std::get<0>(stores_).get());
+    }
+
+    constexpr bool empty() const noexcept
+    {
+        return std::empty(std::get<0>(stores_).get());
+    }
+
+    template<std::size_t N>
+    constexpr std::size_t capacity() const noexcept
+    {
+        return get<N>().capacity();
+    }
+
+    template<typename T>
+    constexpr std::size_t capacity() const noexcept
+    {
+        return get<T>().capacity();
+    }
+
+    constexpr matter::component_view<Ts...>
+    operator[](std::size_t index) noexcept
+    {
+        return std::apply(
+            [&](auto&&... stores) {
+                return matter::component_view<Ts...>{stores.get()[index]...};
+            },
+            stores_);
+    }
+
+    constexpr matter::component_view<std::add_const_t<Ts>...>
+    operator[](std::size_t index) const noexcept
+    {
+        return std::apply(
+            [&](auto&&... stores) {
+                return matter::component_view<std::add_const_t<Ts>...>{
+                    stores.get()[index]...};
+            },
+            stores_);
+    }
+
+    constexpr matter::component_view<Ts...> back() noexcept
+    {
+        return std::apply(
+            [](auto&&... stores) {
+                return matter::component_view<Ts...>{stores.get().back()...};
+            },
+            stores_);
+    }
+
+    constexpr matter::component_view<std::add_const_t<Ts>...> back() const
+        noexcept
+    {
+        return std::apply(
+            [](auto&&... stores) {
+                return matter::component_view<std::add_const_t<Ts>...>{
+                    stores.get().back()...};
+            },
+            stores_);
+    }
+
+    template<typename T>
+    constexpr bool contains() const noexcept
+    {
+        return matter::detail::type_in_list_v<T, Ts...>;
+    }
+
+    template<typename T>
+    constexpr bool contains(const matter::typed_id<id_type, T>&) const noexcept
+    {
+        return contains<T>();
+    }
+
+    template<typename... Us>
+    constexpr bool
+    contains(const matter::unordered_typed_ids<id_type, Us...>&) const noexcept
+    {
+        return (contains<Us>() && ...);
+    }
+
+    template<typename... Us>
+    constexpr bool
+    contains(const matter::ordered_typed_ids<id_type, Us...>&) const noexcept
+    {
+        return (contains<Us>() && ...);
+    }
+
+protected:
+    template<std::size_t N>
+    constexpr auto& get() noexcept
+    {
+        return std::get<N>(stores_).get();
+    }
+
+    template<std::size_t N>
+    constexpr const auto& get() const noexcept
+    {
+        return std::get<N>(stores_).get();
+    }
+
+    template<typename T>
+    constexpr auto& get() noexcept
+    {
+        return std::get<std::reference_wrapper<matter::component_storage_t<T>>>(
+                   stores_)
+            .get();
+    }
+
+    template<typename T>
+    constexpr const auto& get() const noexcept
+    {
+        return std::get<std::reference_wrapper<matter::component_storage_t<T>>>(
+                   stores_)
+            .get();
+    }
+
+public:
+    template<typename _Id, typename... _Ts>
+    friend constexpr std::optional<matter::group_slice<_Id, _Ts...>>
+    make_group_slice(
+        matter::any_group<_Id>                          grp,
+        const matter::unordered_typed_ids<_Id, _Ts...>& ids) noexcept;
+};
+
+template<typename Id, typename... Ts>
+constexpr std::optional<matter::group_slice<Id, Ts...>>
+make_group_slice(matter::any_group<Id>                         grp,
+                 const matter::unordered_typed_ids<Id, Ts...>& ids) noexcept
+{
+    if (ids.size() > grp.group_size())
+    {
+        return std::nullopt;
+    }
+
+    auto opt_stores = grp.maybe_storage(ids);
+
+    if (opt_stores)
+    {
+        return std::apply(
+            [](auto&... stores) {
+                return matter::group_slice<Id, Ts...>{stores...};
+            },
+            *opt_stores);
+    }
+    else
+    {
+        return std::nullopt;
+    }
+}
+} // namespace matter
+
+#endif

--- a/test/test_group_container.cpp
+++ b/test/test_group_container.cpp
@@ -1,7 +1,9 @@
 #include <catch2/catch.hpp>
 
 #include "matter/component/component_identifier.hpp"
+#include "matter/component/group.hpp"
 #include "matter/component/group_container.hpp"
+#include "matter/component/group_slice.hpp"
 
 TEST_CASE("group_container")
 {
@@ -29,19 +31,25 @@ TEST_CASE("group_container")
     CHECK(3 == cont.range().size());
     CHECK(6 == cont.size());
 
-    auto ordered_typed   = ident.ordered_ids<int, float, char>();
-    auto ordered_untyped = matter::ordered_untyped_ids{ordered_typed};
-
     // get here because can get invalidated before
     auto ifcdgrp_opt = cont.find_group(ident.ids<int, float, char, double>());
     CHECK(ifcdgrp_opt);
     auto ifcdgrp = *std::move(ifcdgrp_opt);
-    cont.try_emplace_group(ifcdgrp.underlying_group(), ordered_untyped);
-    CHECK(9 == cont.size());
     // old groups possibly invalidated here
 
     ifcdgrp   = *cont.find_group(ident.ids<int, float, char, double>());
     auto fgrp = *cont.find_group(ident.ids<float>());
+
+    auto fgrp_it = cont.find(ident.ordered_ids<float>());
+    CHECK(fgrp_it != cont.end());
+
+    // obtain the group a different way
+    auto fgrp2 = *matter::make_group(*fgrp_it, ident.ids<float>());
+    CHECK(fgrp == fgrp2);
+
+    // obtain a slice as well
+    auto fgrp_slice = *matter::make_group_slice(*fgrp_it, ident.ids<float>());
+    CHECK(fgrp2 == fgrp_slice);
 
     SECTION("contains")
     {


### PR DESCRIPTION
It's similar to what a `group` was (which now inherits from group_slice). But doesn't offer some methods such as `emplace_back` which would require the presence of all stores to fulfill the contract maintained within a group.

Additionally `group_slice` and `group` are constructed from an `any_group` using `make_group(_slice)`. This method returns an optional to a `group(_slice)`, depending on whether the required stores were present or not.