### PR TITLE
id_cache to retrieve known ids at compile time

### DIFF
--- a/include/matter/id/id_cache.hpp
+++ b/include/matter/id/id_cache.hpp
@@ -1,0 +1,69 @@
+#ifndef MATTER_ID_ID_CACHE_HPP
+#define MATTER_ID_ID_CACHE_HPP
+
+#pragma once
+
+#include <array>
+
+#include <boost/hana/tuple.hpp>
+
+#include "matter/id/component_identifier.hpp"
+#include "matter/id/id.hpp"
+#include "matter/id/typed_id.hpp"
+#include "matter/util/meta.hpp"
+
+namespace matter
+{
+// A place to store needed ids at compile time. The inner workings of this class
+// are nearly identical to unordered_typed_ids, the difference being in the
+// intent of the classes. This class is meant to specifically fulfill the
+// ComponentIdentifier concept.
+template<typename Id, typename... Cs>
+class id_cache {
+    static_assert(matter::is_id_v<Id>);
+
+public:
+    using id_type = Id;
+
+private:
+    std::tuple<matter::typed_id<id_type, Cs>...> ids_;
+
+public:
+    constexpr id_cache(const matter::typed_id<id_type, Cs>&... ids) noexcept
+        : ids_{ids...}
+    {}
+
+    template<typename Identifier>
+    constexpr id_cache(const Identifier& ident)
+        : id_cache{ident.template id<Cs>()...}
+    {
+        static_assert(matter::is_component_identifier_v<Identifier>);
+    }
+
+    template<typename Identifier>
+    constexpr id_cache(const Identifier& ident, boost::hana::basic_type<Cs>...)
+        : id_cache{ident.template id<Cs>()...}
+    {
+        static_assert(matter::is_component_identifier_v<Identifier>);
+    }
+
+    template<typename T>
+    constexpr std::enable_if_t<matter::detail::type_in_list_v<T, Cs...>,
+                               matter::typed_id<id_type, T>>
+    id() const noexcept
+    {
+        return std::get<matter::typed_id<id_type, T>>(ids_);
+    }
+
+    template<typename T>
+    constexpr bool contains() const noexcept
+    {
+        return matter::detail::type_in_list_v<T, Cs...>;
+    }
+};
+template<typename Identifier, typename... Cs>
+id_cache(const Identifier& ident, boost::hana::basic_type<Cs>...)
+    ->id_cache<typename Identifier::id_type, Cs...>;
+} // namespace matter
+
+#endif

--- a/test/meson.build
+++ b/test/meson.build
@@ -11,6 +11,7 @@ tests = [
   'algo',
   'group_container',
   'insert_buffer',
+  'id_cache',
 ]
 
 catch_lib = static_library(

--- a/test/test_id_cache.cpp
+++ b/test/test_id_cache.cpp
@@ -1,0 +1,42 @@
+#include <catch2/catch.hpp>
+
+#include "matter/id/component_identifier.hpp"
+#include "matter/id/default_component_identifier.hpp"
+#include "matter/id/id_cache.hpp"
+
+TEST_CASE("id_cache")
+{
+    SECTION("identifier_construct")
+    {
+        // a main identifier
+        auto ident =
+            matter::default_component_identifier<matter::signed_id<int>>{};
+        ident.register_component<int>();
+        ident.register_component<float>();
+
+        using boost::hana::type_c;
+        // create from hana types
+        auto cache = matter::id_cache{ident, type_c<int>, type_c<float>};
+        // create from typed ids
+        auto cache1 = matter::id_cache{ident.id<float>(), ident.id<int>()};
+        // create without any deduction
+        auto cache2 =
+            matter::id_cache<typename decltype(ident)::id_type, float, int>{
+                ident};
+        (void) cache2;
+
+        static_assert(matter::is_component_identifier_v<decltype(cache)>);
+        static_assert(
+            matter::is_component_identifier_for_v<decltype(cache), int>);
+        // making this work requires use of sfinae
+        static_assert(!matter::is_component_identifier_for_v<
+                      decltype(cache),
+                      matter::prototype::component>);
+
+        REQUIRE(ident.id<int>() == cache.id<int>());
+        REQUIRE(cache.id<float>() == cache1.id<float>());
+
+        REQUIRE(cache.contains<int>());
+        REQUIRE(!cache.contains<char>());
+    }
+}


### PR DESCRIPTION
`id_cache` retrieves required ids at construction from a given identifier and guarantees O(1) access to the stored ids. The stored data is more or less identical to `unordered_typed_ids` but the intention is different. Whereas `unordered_typed_ids` is a method to pass compile time ids around, `id_cache` is meant to be an efficient replacement anywhere normally the `Identifier` would be used to retrieve ids.