### PR TITLE
Entity query primitives

### DIFF
--- a/include/matter/query/access.hpp
+++ b/include/matter/query/access.hpp
@@ -1,0 +1,38 @@
+#ifndef MATTER_QUERY_ACCESS_HPP
+#define MATTER_QUERY_ACCESS_HPP
+
+#pragma once
+
+#include <type_traits>
+
+#include "matter/component/prototype.hpp"
+#include "matter/query/runtime.hpp"
+#include "matter/util/concepts.hpp"
+
+namespace matter
+{
+template<typename T, typename = void>
+struct is_access : std::false_type
+{};
+
+/// Access specifiers can be seen as modifiers to the base type of storage. This
+/// is done so that we can safely evaluate whether concurrent access is possible
+/// or not.
+template<typename T>
+struct is_access<
+    T,
+    std::enable_if_t<
+        std::is_same_v<matter::access, decltype(T::access_enum())> &&
+            matter::is_optional_v<decltype(
+                std::declval<const typename T::storage_modifier>()(
+                    std::declval<matter::component_storage_t<
+                        matter::prototype::component>*>()))> &&
+            std::is_default_constructible_v<typename T::storage_modifier>,
+        std::void_t<typename T::storage_modifier>>> : std::true_type
+{};
+
+template<typename T>
+constexpr bool is_access_v = is_access<T>::value;
+} // namespace matter
+
+#endif

--- a/include/matter/query/component_query_description.hpp
+++ b/include/matter/query/component_query_description.hpp
@@ -1,0 +1,137 @@
+#ifndef MATTER_QUERY_COMPONENT_QUERY_DESCRIPTION_HPP
+#define MATTER_QUERY_COMPONENT_QUERY_DESCRIPTION_HPP
+
+#pragma once
+
+#include "matter/id/component_identifier.hpp"
+#include "matter/id/id.hpp"
+#include "matter/query/access.hpp"
+#include "matter/query/presence.hpp"
+#include "matter/query/runtime.hpp"
+#include "matter/query/typed_access.hpp"
+
+namespace matter
+{
+template<typename Id>
+class component_query_description {
+    static_assert(matter::is_id_v<Id>);
+
+public:
+    using id_type = Id;
+
+private:
+    const id_type          id_;
+    const matter::access   access_;
+    const matter::presence pres_;
+
+public:
+    constexpr component_query_description(const id_type&   id,
+                                          matter::access   acc,
+                                          matter::presence pres) noexcept
+        : id_{id}, access_{acc}, pres_{pres}
+    {}
+
+    template<typename Identifier,
+             typename T,
+             typename Access,
+             typename Presence>
+    constexpr component_query_description(
+        const Identifier& ident,
+        boost::hana::basic_type<
+            matter::typed_access<T, Access, Presence>>) noexcept
+        : id_{ident.template id<T>()}, access_{Access::access_enum()},
+          pres_{Presence::presence_enum()}
+    {
+        static_assert(matter::is_component_identifier_v<Identifier>);
+    }
+
+    constexpr const id_type& id() const noexcept
+    {
+        return id_;
+    }
+
+    constexpr matter::presence presence() const noexcept
+    {
+        return pres_;
+    }
+
+    constexpr matter::access access() const noexcept
+    {
+        return access_;
+    }
+
+    constexpr bool is_read() const noexcept
+    {
+        return access() == matter::access::read;
+    }
+
+    constexpr bool is_write() const noexcept
+    {
+        return access() == matter::access::write;
+    }
+
+    constexpr bool is_inaccessible() const noexcept
+    {
+        return access() == matter::access::inaccessible;
+    }
+
+    constexpr bool is_required() const noexcept
+    {
+        return presence() == matter::presence::require;
+    }
+
+    constexpr bool is_optional() const noexcept
+    {
+        return presence() == matter::presence::optional;
+    }
+
+    constexpr bool is_excluded() const noexcept
+    {
+        return presence() == matter::presence::exclude;
+    }
+
+    // used to verify whether 2 queries can coexist concurrently, this member
+    // function gets used for both the runtime calculation of concurrency and at
+    // compile time.
+    constexpr bool can_access_concurrent(
+        const component_query_description<id_type>& other) const noexcept
+    {
+        // if we require no access then we can always run concurrently
+        if (is_inaccessible() || other.is_inaccessible())
+        {
+            return true;
+        }
+
+        if (id() != other.id()) // id is different, don't care
+        {
+            return true;
+        }
+
+        // if both have the exclude presence specified then no mutation can take
+        // place anyway
+        if (is_excluded() || other.is_excluded())
+        {
+            return true;
+        }
+
+        // either required or optional in here
+        // with required or optional we now need to check for write/read
+        // access reads can occur concurrently but any write cannot
+        if (is_write() || other.is_write())
+        {
+            return false;
+        }
+
+        // both are only reading, safe concurrency
+        return true;
+    }
+};
+
+template<typename Identifier, typename T, typename Access, typename Presence>
+component_query_description(
+    const Identifier& ident,
+    boost::hana::basic_type<matter::typed_access<T, Access, Presence>>)
+    ->component_query_description<typename Identifier::id_type>;
+} // namespace matter
+
+#endif

--- a/include/matter/query/presence.hpp
+++ b/include/matter/query/presence.hpp
@@ -1,0 +1,39 @@
+#ifndef MATTER_QUERY_PRESENCE_HPP
+#define MATTER_QUERY_PRESENCE_HPP
+
+#pragma once
+
+#include <type_traits>
+
+#include "matter/query/runtime.hpp"
+#include "matter/util/concepts.hpp"
+#include "matter/util/prototype.hpp"
+
+namespace matter
+{
+template<typename T, typename = void>
+struct is_presence : std::false_type
+{};
+
+/// Presence specifiers can be seen as a sort of filter, this is the reason why
+/// all return values must fulfill the Optional concept.
+/// Additionally it gets passed the type modified by the access specifier, which
+/// is also required to be optional. So the processing functor must work with
+/// all types which fulfill the optional concept.
+template<typename T>
+struct is_presence<
+    T,
+    std::enable_if_t<
+        matter::is_optional_v<
+            std::invoke_result_t<typename T::storage_filter,
+                                 matter::prototype::optional>> &&
+            std::is_same_v<matter::presence, decltype(T::presence_enum())> &&
+            std::is_default_constructible_v<typename T::storage_filter>,
+        std::void_t<typename T::storage_filter>>> : std::true_type
+{};
+
+template<typename T>
+constexpr bool is_presence_v = is_presence<T>::value;
+} // namespace matter
+
+#endif

--- a/include/matter/query/primitives/concurrency.hpp
+++ b/include/matter/query/primitives/concurrency.hpp
@@ -1,0 +1,85 @@
+#ifndef MATTER_QUERY_PRIMITIVES_CONCURRENCY_HPP
+#define MATTER_QUERY_PRIMITIVES_CONCURRENCY_HPP
+
+#pragma once
+
+#include <boost/hana/type.hpp>
+
+#include "matter/id/id.hpp"
+#include "matter/id/typed_id.hpp"
+#include "matter/query/component_query_description.hpp"
+#include "matter/query/typed_access.hpp"
+
+namespace matter
+{
+namespace detail
+{
+// this identifier is used to unify the concurrency checking code at runtime and
+// compile time.
+template<typename T, typename U>
+class mock_component_identifier {
+public:
+    using id_type = matter::signed_id<int>;
+
+    template<typename TAccess,
+             typename TPresence,
+             typename UAccess,
+             typename UPresence>
+    constexpr mock_component_identifier(
+        boost::hana::basic_type<matter::typed_access<T, TAccess, TPresence>>,
+        boost::hana::basic_type<
+            matter::typed_access<U, UAccess, UPresence>>) noexcept
+    {}
+
+    template<typename V>
+    constexpr bool contains() const noexcept
+    {
+        if constexpr (std::is_same_v<V, T> || std::is_same_v<V, U>)
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    // this just gives the id of 0 for one and 1 for the other
+    template<typename V>
+    constexpr std::enable_if_t<std::is_same_v<V, T> || std::is_same_v<V, U>,
+                               matter::typed_id<id_type, V>>
+    id() const noexcept
+    {
+        if constexpr (std::is_same_v<V, T>)
+        {
+            return matter::typed_id<id_type, V>{matter::signed_id<int>{0}};
+        }
+        else // has to be U now
+        {
+            return matter::typed_id<id_type, V>{matter::signed_id<int>{1}};
+        }
+    }
+};
+} // namespace detail
+
+template<typename T,
+         typename TAccess,
+         typename TPresence,
+         typename U,
+         typename UAccess,
+         typename UPresence>
+constexpr bool can_access_concurrent(
+    boost::hana::basic_type<matter::typed_access<T, TAccess, TPresence>> lhs,
+    boost::hana::basic_type<matter::typed_access<U, UAccess, UPresence>>
+        rhs) noexcept
+{
+    constexpr auto ident = matter::detail::mock_component_identifier{lhs, rhs};
+
+    constexpr auto lhs_descr = matter::component_query_description{ident, lhs};
+    constexpr auto rhs_descr = matter::component_query_description{ident, rhs};
+
+    return lhs_descr.can_access_concurrent(rhs_descr);
+}
+} // namespace matter
+
+#endif

--- a/include/matter/query/primitives/exclude.hpp
+++ b/include/matter/query/primitives/exclude.hpp
@@ -1,0 +1,42 @@
+#ifndef MATTER_QUERY_PRIMITIVES_EXCLUDE_HPP
+#define MATTER_QUERY_PRIMITIVES_EXCLUDE_HPP
+
+#pragma once
+
+#include <optional>
+
+#include "matter/query/runtime.hpp"
+#include "matter/util/empty.hpp"
+
+namespace matter
+{
+namespace prim
+{
+struct exclude
+{
+    struct storage_filter
+    {
+        template<typename Storage>
+        constexpr std::optional<matter::empty>
+        operator()(Storage store) noexcept
+        {
+            if (store)
+            {
+                return std::nullopt;
+            }
+            else
+            {
+                return matter::empty{};
+            }
+        }
+    };
+
+    static constexpr matter::presence presence_enum() noexcept
+    {
+        return presence::exclude;
+    }
+};
+} // namespace prim
+} // namespace matter
+
+#endif

--- a/include/matter/query/primitives/filter.hpp
+++ b/include/matter/query/primitives/filter.hpp
@@ -1,0 +1,101 @@
+#ifndef MATTER_QUERY_COMPONENT_FILTER_HPP
+#define MATTER_QUERY_COMPONENT_FILTER_HPP
+
+#pragma once
+
+#include "matter/component/any_group.hpp"
+#include "matter/query/component_query_description.hpp"
+#include "matter/query/typed_access.hpp"
+
+namespace matter
+{
+template<typename Identifier, typename T, typename Access, typename Presence>
+constexpr decltype(auto) filter_group(
+    matter::any_group<typename Identifier::id_type> grp,
+    const Identifier&                               ident,
+    boost::hana::basic_type<matter::typed_access<T, Access, Presence>>) noexcept
+{
+    using element_type          = T;
+    using storage_modifier_type = typename Access::storage_modifier;
+    using storage_filter_type   = typename Presence::storage_filter;
+
+    auto type_id = ident.template id<element_type>();
+
+    auto* store = grp.maybe_storage(type_id);
+
+    auto modifier = storage_modifier_type{};
+    auto filter   = storage_filter_type{};
+
+    auto modified_store = modifier(store);
+    return filter(modified_store);
+}
+
+// filter the group for the specified access.
+// this function will return a result of the form
+// std::optional<std::tuple<component_storage<T>, ...>>. Where nullopt means the
+// filtering failed and the group does not qualify.
+template<typename Identifier,
+         typename... Ts,
+         typename... Access,
+         typename... Presence>
+constexpr auto filter_group(
+    matter::any_group<typename Identifier::id_type> grp,
+    const Identifier&                               ident,
+    boost::hana::basic_type<
+        matter::typed_access<Ts, Access, Presence>>... access_types) noexcept
+{
+    auto process_storage = [&](auto tid, auto access_type) {
+        using storage_modifier_type =
+            typename decltype(access_type)::type::access_type::storage_modifier;
+        using storage_filter_type =
+            typename decltype(access_type)::type::presence_type::storage_filter;
+
+        auto* store = grp.maybe_storage(tid);
+
+        auto modifier = storage_modifier_type{};
+        auto filter   = storage_filter_type{};
+
+        auto modified_store = modifier(store);
+        return filter(modified_store);
+    };
+
+    auto results = std::tuple<decltype(
+        process_storage(ident.template id<Ts>(), access_types))...>{};
+
+    auto shortcircuit = [&](auto tid, auto access_type) {
+        auto filter_res = process_storage(tid, access_type);
+
+        bool result                             = bool(filter_res);
+        std::get<decltype(filter_res)>(results) = std::move(filter_res);
+
+        return result;
+    };
+
+    // this will terminate prematurely on false result.
+    // because if one filter doesn't pass then we can throw away the result
+    // either way
+    auto success = (shortcircuit(ident.template id<Ts>(), access_types) && ...);
+
+    auto dereference_results = [](auto&& result) {
+        return std::apply(
+            [](auto&&... results) {
+                return std::optional{std::make_tuple(*std::move(results)...)};
+            },
+            std::move(result));
+    };
+
+    using optional_type = decltype(dereference_results(std::move(results)));
+
+    if (success)
+    {
+        return dereference_results(std::move(results));
+    }
+    else
+    {
+        return optional_type{std::nullopt};
+    }
+}
+// TODO: filtering for runtime component access
+} // namespace matter
+
+#endif

--- a/include/matter/query/primitives/inaccessible.hpp
+++ b/include/matter/query/primitives/inaccessible.hpp
@@ -1,0 +1,70 @@
+#ifndef MATTER_QUERY_PRIMITIVES_INACCESSIBLE_HPP
+#define MATTER_QUERY_PRIMITIVES_INACCESSIBLE_HPP
+
+#pragma once
+
+#include "matter/component/traits.hpp"
+#include "matter/query/runtime.hpp"
+#include "matter/util/empty.hpp"
+
+namespace matter
+{
+namespace detail
+{
+template<typename T>
+class inaccessible_impl {
+public:
+    using element_type = T;
+
+private:
+    bool valid_{false};
+
+public:
+    constexpr inaccessible_impl() noexcept = default;
+    constexpr inaccessible_impl(std::nullptr_t) noexcept : valid_{false}
+    {}
+
+    constexpr inaccessible_impl(T* ptr) noexcept : valid_{ptr}
+    {}
+
+    constexpr inaccessible_impl<T>& operator=(T* ptr) noexcept
+    {
+        valid_ = ptr;
+        return *this;
+    }
+
+    explicit constexpr operator bool() const noexcept
+    {
+        return valid_;
+    }
+
+    constexpr matter::empty operator*() const noexcept
+    {
+        return {};
+    }
+};
+} // namespace detail
+
+namespace prim
+{
+struct inaccessible
+{
+    struct storage_modifier
+    {
+        template<typename T>
+        constexpr matter::detail::inaccessible_impl<T>
+        operator()(T* store) const noexcept
+        {
+            return matter::detail::inaccessible_impl{store};
+        }
+    };
+
+    static constexpr matter::access access_enum() noexcept
+    {
+        return matter::access::inaccessible;
+    }
+};
+} // namespace prim
+} // namespace matter
+
+#endif

--- a/include/matter/query/primitives/optional.hpp
+++ b/include/matter/query/primitives/optional.hpp
@@ -1,0 +1,34 @@
+#ifndef MATTER_QUERY_PRIMITIVES_OPTIONAL_HPP
+#define MATTER_QUERY_PRIMITIVES_OPTIONAL_HPP
+
+#pragma once
+
+#include <optional>
+
+#include "matter/query/runtime.hpp"
+
+namespace matter
+{
+namespace prim
+{
+struct optional
+{
+    struct storage_filter
+    {
+        template<typename Storage>
+        constexpr std::optional<Storage> operator()(Storage store) const
+            noexcept
+        {
+            return store;
+        }
+    };
+
+    static constexpr matter::presence presence_enum() noexcept
+    {
+        return presence::optional;
+    }
+};
+} // namespace prim
+} // namespace matter
+
+#endif

--- a/include/matter/query/primitives/read.hpp
+++ b/include/matter/query/primitives/read.hpp
@@ -1,0 +1,34 @@
+#ifndef MATTER_QUERY_PRIMITIVES_READ_HPP
+#define MATTER_QUERY_PRIMITIVES_READ_HPP
+
+#pragma once
+
+#include "matter/component/traits.hpp"
+#include "matter/query/runtime.hpp"
+#include "matter/util/concepts.hpp"
+
+namespace matter
+{
+namespace prim
+{
+struct read
+{
+    struct storage_modifier
+    {
+        template<typename T>
+        constexpr std::enable_if_t<matter::is_optional_v<T>, const T>
+        operator()(T store) const noexcept
+        {
+            return store;
+        }
+    };
+
+    static constexpr matter::access access_enum() noexcept
+    {
+        return matter::access::read;
+    }
+};
+} // namespace prim
+} // namespace matter
+
+#endif

--- a/include/matter/query/primitives/require.hpp
+++ b/include/matter/query/primitives/require.hpp
@@ -1,0 +1,31 @@
+#ifndef MATTER_QUERY_PRIMITIVES_REQUIRE_HPP
+#define MATTER_QUERY_PRIMITIVES_REQUIRE_HPP
+
+#pragma once
+
+#include "matter/query/runtime.hpp"
+
+namespace matter
+{
+namespace prim
+{
+struct require
+{
+    struct storage_filter
+    {
+        template<typename Storage>
+        constexpr Storage operator()(Storage store) const noexcept
+        {
+            return store;
+        }
+    };
+
+    static constexpr matter::presence presence_enum() noexcept
+    {
+        return presence::require;
+    }
+};
+} // namespace prim
+} // namespace matter
+
+#endif

--- a/include/matter/query/primitives/write.hpp
+++ b/include/matter/query/primitives/write.hpp
@@ -1,0 +1,34 @@
+#ifndef MATTER_QUERY_PRIMITIVES_WRITE_HPP
+#define MATTER_QUERY_PRIMITIVES_WRITE_HPP
+
+#pragma once
+
+#include "matter/component/traits.hpp"
+#include "matter/query/runtime.hpp"
+#include "matter/util/concepts.hpp"
+
+namespace matter
+{
+namespace prim
+{
+struct write
+{
+    struct storage_modifier
+    {
+        template<typename T>
+        constexpr std::enable_if_t<matter::is_optional_v<T>, T>
+        operator()(T store) const noexcept
+        {
+            return store;
+        }
+    };
+
+    static constexpr matter::access access_enum() noexcept
+    {
+        return matter::access::write;
+    }
+};
+} // namespace prim
+} // namespace matter
+
+#endif

--- a/include/matter/query/runtime.hpp
+++ b/include/matter/query/runtime.hpp
@@ -1,0 +1,24 @@
+#ifndef MATTER_QUERY_RUNTIME_HPP
+#define MATTER_QUERY_RUNTIME_HPP
+
+#pragma once
+
+namespace matter
+{
+enum struct access
+{
+    read,
+    write,
+    inaccessible
+};
+
+// the enum used to get information in a dynamic context
+enum struct presence
+{
+    require,
+    optional,
+    exclude
+};
+} // namespace matter
+
+#endif

--- a/include/matter/query/typed_access.hpp
+++ b/include/matter/query/typed_access.hpp
@@ -1,0 +1,34 @@
+#ifndef MATTER_QUERY_COMPONENT_TYPED_ACCESS_HPP
+#define MATTER_QUERY_COMPONENT_TYPED_ACCESS_HPP
+
+#pragma once
+
+#include "matter/query/access.hpp"
+#include "matter/query/presence.hpp"
+
+namespace matter
+{
+template<typename T, typename Access, typename Presence>
+class typed_access {
+    static_assert(matter::is_access_v<Access>);
+    static_assert(matter::is_presence_v<Presence>);
+
+public:
+    using element_type = T;
+
+    using access_type   = Access;
+    using presence_type = Presence;
+
+    static constexpr matter::access access_enum() noexcept
+    {
+        return access_type::access_enum();
+    }
+
+    static constexpr matter::presence presence_enum() noexcept
+    {
+        return presence_type::presence_enum();
+    }
+};
+} // namespace matter
+
+#endif

--- a/include/matter/util/concepts.hpp
+++ b/include/matter/util/concepts.hpp
@@ -69,9 +69,12 @@ struct is_optional : std::false_type
 {};
 
 template<typename T>
-struct is_optional<T,
-                   std::void_t<decltype(bool(std::declval<const T>())),
-                               decltype(*std::declval<T>())>> : std::true_type
+struct is_optional<
+    T,
+    std::enable_if_t<std::is_default_constructible_v<T>,
+                     std::void_t<decltype(bool(std::declval<const T>())),
+                                 decltype(*std::declval<T>())>>>
+    : std::true_type
 {};
 
 template<typename T>

--- a/include/matter/util/empty.hpp
+++ b/include/matter/util/empty.hpp
@@ -1,0 +1,12 @@
+#ifndef MATTER_UTIL_EMPTY_HPP
+#define MATTER_UTIL_EMPTY_HPP
+
+#pragma once
+
+namespace matter
+{
+// this is a canonical empty class, not holding anything
+class empty {};
+} // namespace matter
+
+#endif

--- a/include/matter/util/prototype.hpp
+++ b/include/matter/util/prototype.hpp
@@ -1,0 +1,22 @@
+#ifndef MATTER_UTIL_PROTOTYPE_HPP
+#define MATTER_UTIL_PROTOTYPE_HPP
+
+#pragma once
+
+#include "matter/util/concepts.hpp"
+
+namespace matter
+{
+namespace prototype
+{
+struct optional
+{
+    explicit operator bool() const;
+    int      operator*() const;
+};
+
+static_assert(matter::is_optional_v<matter::prototype::optional>);
+} // namespace prototype
+} // namespace matter
+
+#endif

--- a/test/meson.build
+++ b/test/meson.build
@@ -12,6 +12,7 @@ tests = [
   'group_container',
   'insert_buffer',
   'id_cache',
+  'query',
 ]
 
 catch_lib = static_library(

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -1,0 +1,183 @@
+#include <catch2/catch.hpp>
+
+#include "matter/component/registry.hpp"
+#include "matter/id/default_component_identifier.hpp"
+#include "matter/id/id_cache.hpp"
+#include "matter/query/primitives/concurrency.hpp"
+#include "matter/query/primitives/exclude.hpp"
+#include "matter/query/primitives/filter.hpp"
+#include "matter/query/primitives/inaccessible.hpp"
+#include "matter/query/primitives/optional.hpp"
+#include "matter/query/primitives/read.hpp"
+#include "matter/query/primitives/require.hpp"
+#include "matter/query/primitives/write.hpp"
+#include "matter/query/typed_access.hpp"
+
+TEST_CASE("query")
+{
+    SECTION("concurrency")
+    {
+        using boost::hana::type_c;
+        auto winte = type_c<matter::typed_access<int,
+                                                 matter::prim::write,
+                                                 matter::prim::exclude>>;
+        auto wintr = type_c<matter::typed_access<int,
+                                                 matter::prim::write,
+                                                 matter::prim::require>>;
+        auto winto = type_c<matter::typed_access<int,
+                                                 matter::prim::write,
+                                                 matter::prim::optional>>;
+
+        auto iintr = type_c<matter::typed_access<int,
+                                                 matter::prim::inaccessible,
+                                                 matter::prim::require>>;
+
+        SECTION("static")
+        {
+            static_assert(!matter::can_access_concurrent(wintr, wintr));
+            static_assert(matter::can_access_concurrent(winte, wintr));
+            static_assert(matter::can_access_concurrent(winte, winto));
+
+            static_assert(matter::can_access_concurrent(wintr, iintr));
+        }
+
+        SECTION("dynamic")
+        {
+            auto ident =
+                matter::default_component_identifier<matter::signed_id<int>>{};
+            ident.register_component<int>();
+
+            auto winte_descr =
+                matter::component_query_description{ident, winte};
+            auto wintr_descr =
+                matter::component_query_description{ident, wintr};
+            auto winto_descr =
+                matter::component_query_description{ident, winto};
+            auto iintr_descr =
+                matter::component_query_description{ident, iintr};
+
+            REQUIRE(!wintr_descr.can_access_concurrent(wintr_descr));
+            REQUIRE(winte_descr.can_access_concurrent(wintr_descr));
+            REQUIRE(winte_descr.can_access_concurrent(winto_descr));
+            REQUIRE(iintr_descr.can_access_concurrent(wintr_descr));
+        }
+    }
+
+    SECTION("filter")
+    {
+        auto reg = matter::registry<
+            matter::default_component_identifier<matter::signed_id<int>>>{};
+        reg.register_component<int>();
+        reg.register_component<float>();
+
+        reg.create<int, float>(
+            std::make_tuple(1),
+            std::make_tuple(5.0f));               // create [int, float] group
+        reg.create<float>(std::make_tuple(5.0f)); // create [float] group
+        reg.create<int>(std::make_tuple(3));      // create [int] group
+
+        auto grp_range = reg.group_container().range();
+
+        auto cache = matter::id_cache{reg.component_id<int>(),
+                                      reg.component_id<float>()};
+
+        auto matched = 0;
+
+        for (auto grp : grp_range)
+        {
+            auto filtered_group = matter::filter_group(
+                grp,
+                cache,
+                boost::hana::type_c<
+                    matter::typed_access<int,
+                                         matter::prim::write,
+                                         matter::prim::require>>);
+
+            if (filtered_group) // [int] and [int, float] should match
+            {
+                ++matched;
+            }
+        }
+
+        REQUIRE(matched == 2); // the number of matched groups
+        matched = 0;
+
+        for (auto grp : grp_range)
+        {
+            // match all without float, so should be 1 [int]
+            auto filtered_group = matter::filter_group(
+                grp,
+                cache,
+                boost::hana::type_c<
+                    matter::typed_access<float,
+                                         matter::prim::inaccessible,
+                                         matter::prim::exclude>>);
+
+            if (filtered_group)
+            {
+                static_assert(
+                    std::is_same_v<
+                        matter::empty,
+                        std::decay_t<decltype(*std::move(filtered_group))>>);
+                ++matched;
+            }
+        }
+
+        REQUIRE(matched == 1);
+
+        // filter multiple types at the same time
+        SECTION("multiple")
+        {
+            matched = 0;
+
+            for (auto grp : grp_range)
+            {
+                auto res = matter::filter_group(
+                    grp,
+                    cache,
+                    boost::hana::type_c<
+                        matter::typed_access<float,
+                                             matter::prim::read,
+                                             matter::prim::optional>>,
+                    boost::hana::type_c<
+                        matter::typed_access<int,
+                                             matter::prim::write,
+                                             matter::prim::require>>);
+
+                // should match on [int, float] and [int]
+                if (res)
+                {
+                    ++matched;
+                }
+            }
+
+            REQUIRE(matched == 2);
+
+            matched = 0;
+
+            for (auto grp : grp_range)
+            {
+                // match all with int and without float, so [int]
+                using boost::hana::type_c;
+                auto res = matter::filter_group(
+                    grp,
+                    cache,
+                    type_c<matter::typed_access<float,
+                                                matter::prim::read,
+                                                matter::prim::exclude>>,
+                    type_c<matter::typed_access<int,
+                                                matter::prim::read,
+                                                matter::prim::require>>);
+
+                if (res)
+                {
+                    ++matched;
+                    auto [fstore, istore] = *std::move(res);
+                    REQUIRE(istore[0] == 3);
+                }
+            }
+
+            REQUIRE(matched == 1);
+        }
+    }
+}


### PR DESCRIPTION
These primitives allow filtering groups and obtaining the stores we're interested in. Additionally they have compile time and runtime checks to see whether component access can run concurrently or not.