### PR TITLE
Entities query

### DIFF
--- a/include/matter/query/entities.hpp
+++ b/include/matter/query/entities.hpp
@@ -1,0 +1,48 @@
+#ifndef MATTER_QUERY_ENTITIES_HPP
+#define MATTER_QUERY_ENTITIES_HPP
+
+#pragma once
+
+#include "matter/query/typed_access.hpp"
+#include "matter/util/filter_transform.hpp"
+
+namespace matter
+{
+template<typename... TypeAccess>
+class entities;
+
+template<typename... Ts, typename... Access, typename... Presence>
+class entities<matter::typed_access<Ts, Access, Presence>...> {
+public:
+    constexpr entities(boost::hana::basic_type<
+                       matter::typed_access<Ts, Access, Presence>>...) noexcept
+    {}
+
+    /// normally we receive a range of all filtered groups as an optional. All
+    /// this function does it only return the unwrapped optionals which hold a
+    /// value.
+    /// turning `[some(a), some(b), none, some(c)]` into `[a, b, c]`.
+    template<typename Range>
+    constexpr decltype(auto) operator()(Range&& group_rng) const noexcept
+    {
+        return std::forward<Range>(group_rng) |
+               filter_transform([](auto&& opt_result) {
+                   return std::forward<decltype(opt_result)>(opt_result);
+               });
+    }
+
+    constexpr auto query_types() const noexcept
+    {
+
+        return boost::hana::tuple_t<
+            matter::typed_access<Ts, Access, Presence>...>;
+    }
+};
+
+template<typename... Ts, typename... Access, typename... Presence>
+entities(boost::hana::basic_type<
+         matter::typed_access<Ts, Access, Presence>>...) noexcept
+    ->entities<matter::typed_access<Ts, Access, Presence>...>;
+} // namespace matter
+
+#endif

--- a/include/matter/query/entity_query_processor.hpp
+++ b/include/matter/query/entity_query_processor.hpp
@@ -1,0 +1,46 @@
+#ifndef MATTER_QUERY_ENTITY_QUERY_PROCESSOR_HPP
+#define MATTER_QUERY_ENTITY_QUERY_PROCESSOR_HPP
+
+#pragma once
+
+#include <boost/hana/tuple.hpp>
+#include <range/v3/view/transform.hpp>
+
+#include "matter/id/id_cache.hpp"
+#include "matter/query/primitives/filter.hpp"
+#include "matter/query/typed_access.hpp"
+
+namespace matter
+{
+class entity_query_processor {
+public:
+    // returns a range of optional query results, When the query passed the
+    // optional will be filled, otherwise it will be empty.
+    template<typename Identifier,
+             typename Range,
+             typename... Ts,
+             typename... Access,
+             typename... Presence>
+    constexpr decltype(auto) operator()(
+        Range&&           group_range,
+        const Identifier& ident,
+        boost::hana::basic_type<
+            matter::typed_access<Ts, Access, Presence>>... query_types) const
+        noexcept
+    {
+        // use the filter_group function to determine whether the group is
+        // valid. receive an empty optional if not.
+        return ranges::transform_view(
+            std::forward<Range>(group_range),
+            [         =,
+             id_cache = matter::id_cache{
+                 ident,
+                 boost::hana::type_c<typename decltype(
+                     query_types)::type::element_type>...}](auto grp) {
+                return matter::filter_group(grp, id_cache, query_types...);
+            });
+    }
+};
+} // namespace matter
+
+#endif

--- a/include/matter/query/primitives/filter.hpp
+++ b/include/matter/query/primitives/filter.hpp
@@ -9,27 +9,6 @@
 
 namespace matter
 {
-template<typename Identifier, typename T, typename Access, typename Presence>
-constexpr decltype(auto) filter_group(
-    matter::any_group<typename Identifier::id_type> grp,
-    const Identifier&                               ident,
-    boost::hana::basic_type<matter::typed_access<T, Access, Presence>>) noexcept
-{
-    using element_type          = T;
-    using storage_modifier_type = typename Access::storage_modifier;
-    using storage_filter_type   = typename Presence::storage_filter;
-
-    auto type_id = ident.template id<element_type>();
-
-    auto* store = grp.maybe_storage(type_id);
-
-    auto modifier = storage_modifier_type{};
-    auto filter   = storage_filter_type{};
-
-    auto modified_store = modifier(store);
-    return filter(modified_store);
-}
-
 // filter the group for the specified access.
 // this function will return a result of the form
 // std::optional<std::tuple<component_storage<T>, ...>>. Where nullopt means the

--- a/include/matter/util/filter_transform.hpp
+++ b/include/matter/util/filter_transform.hpp
@@ -1,0 +1,36 @@
+#ifndef MATTER_UTIL_FILTER_TRANSFORM_HPP
+#define MATTER_UTIL_FILTER_TRANSFORM_HPP
+
+#pragma once
+
+#include <range/v3/view/filter.hpp>
+#include <range/v3/view/transform.hpp>
+
+namespace matter
+{
+/// A convenience for filtering and transforming at the same time, the predicate
+/// must return the transformed element as an optional (pointer or std::optional
+/// works). If the optional evaluates to true it will be dereferenced and
+/// accessible in the resulting range, otherwise it will be discarded.
+template<typename Pred>
+constexpr decltype(auto) filter_transform(Pred p)
+{
+    return ranges::view::transform([p = std::move(p)](auto&& element) {
+               return p(std::forward<decltype(element)>(element));
+           }) |
+           ranges::view::filter([](auto&& opt_element) -> bool {
+               return opt_element.has_value();
+           }) |
+           ranges::view::transform([](auto&& opt_element) {
+               return *std::forward<decltype(opt_element)>(opt_element);
+           });
+}
+
+template<typename Rng, typename Pred>
+constexpr decltype(auto) filter_transform_view(Rng&& range, Pred p)
+{
+    return std::forward<Rng>(range) | filter_transform(std::move(p));
+}
+} // namespace matter
+
+#endif


### PR DESCRIPTION
Create an `entities` type which take `typed_access` types and allows us to retrieve entities matching the interface. This is the first step to defining a usable interface for jobs.