### PR TITLE
SoA container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ CMakeSettings.json
 .cquery_cached_index/
 .cquery
 compile_flags.txt
+.vscode/

--- a/include/matter/concepts/assignable_from.hpp
+++ b/include/matter/concepts/assignable_from.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <utility>
+
+#include "matter/concepts/common_reference_with.hpp"
+#include "matter/concepts/same_as.hpp"
+
+namespace matter
+{
+template<typename LHS, typename RHS>
+concept assignable_from = std::is_lvalue_reference_v<LHS>&&
+    common_reference_with<
+        const std::remove_reference_t<LHS>&,
+        const std::remove_reference_t<RHS>&>&& // clang-format off
+    requires(LHS lhs, RHS&& rhs) {
+        { lhs = std::forward<RHS>(rhs) };
+        requires same_as<decltype(lhs = std::forward<RHS>(rhs)), LHS>;
+    }; // clang-format on
+} // namespace matter

--- a/include/matter/concepts/boolean.hpp
+++ b/include/matter/concepts/boolean.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "matter/concepts/convertible_to.hpp"
+#include "matter/concepts/movable.hpp"
+
+namespace matter
+{
+template<typename B>
+concept boolean = // clang-format off
+    movable<std::remove_cvref_t<B>> &&
+    requires(const std::remove_reference_t<B>& b1,
+             const std::remove_reference_t<B>& b2, const bool a)
+    {
+        {  b1 } -> convertible_to<bool>;
+        { !b1 } -> convertible_to<bool>;
+        { b1 && b2 } -> convertible_to<bool>;
+        { b1 &&  a } -> convertible_to<bool>;
+        {  a && b2 } -> convertible_to<bool>;
+        { b1 || b2 } -> convertible_to<bool>;
+        { b1 ||  a } -> convertible_to<bool>;
+        {  a || b2 } -> convertible_to<bool>;
+        { b1 == b2 } -> convertible_to<bool>;
+        { b1 ==  a } -> convertible_to<bool>;
+        {  a == b2 } -> convertible_to<bool>;
+        { b1 != b2 } -> convertible_to<bool>;
+        { b1 !=  a } -> convertible_to<bool>;
+        {  a != b2 } -> convertible_to<bool>;
+    }; // clang-format on
+} // namespace matter

--- a/include/matter/concepts/common_reference_with.hpp
+++ b/include/matter/concepts/common_reference_with.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "matter/concepts/convertible_to.hpp"
+#include "matter/concepts/same_as.hpp"
+#include "matter/utility/common_reference.hpp"
+
+namespace matter
+{
+template<typename T, typename U>
+concept common_reference_with =
+    same_as<common_reference_t<T, U>, common_reference_t<U, T>>&&
+            convertible_to<T, common_reference_t<T, U>>&&
+            convertible_to<U, common_reference_t<T, U>>;
+}

--- a/include/matter/concepts/constructible_from.hpp
+++ b/include/matter/concepts/constructible_from.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "matter/concepts/destructible.hpp"
+
+namespace matter
+{
+template<typename T, typename... Args>
+concept constructible_from =
+    destructible<T>&& std::is_constructible_v<T, Args...>;
+}

--- a/include/matter/concepts/convertible_to.hpp
+++ b/include/matter/concepts/convertible_to.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <type_traits>
+
+namespace matter
+{
+template<typename From, typename To>
+concept convertible_to = // clang-format off
+    std::is_convertible_v<From, To>&& 
+    requires(From (&f)())
+    {
+        static_cast<To>(f());
+    }; // clang-format on
+} // namespace matter

--- a/include/matter/concepts/copy_constructible.hpp
+++ b/include/matter/concepts/copy_constructible.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "matter/concepts/constructible_from.hpp"
+#include "matter/concepts/convertible_to.hpp"
+#include "matter/concepts/move_constructible.hpp"
+
+namespace matter
+{
+template<typename T>
+concept copy_constructible =
+    move_constructible<T>&& constructible_from<T, T&>&& convertible_to<T&, T>&&
+        constructible_from<T, const T&>&& convertible_to<const T&, T>&&
+            constructible_from<T, const T>&& convertible_to<const T, T>;
+}

--- a/include/matter/concepts/copyable.hpp
+++ b/include/matter/concepts/copyable.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "matter/concepts/assignable_from.hpp"
+#include "matter/concepts/copy_constructible.hpp"
+#include "matter/concepts/movable.hpp"
+
+namespace matter
+{
+template<typename T>
+concept copyable =
+    copy_constructible<T>&& movable<T>&& assignable_from<T&, const T&>;
+}

--- a/include/matter/concepts/default_constructible.hpp
+++ b/include/matter/concepts/default_constructible.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "matter/concepts/constructible_from.hpp"
+
+namespace matter
+{
+template<typename T>
+concept default_constructible = constructible_from<T>;
+}

--- a/include/matter/concepts/destructible.hpp
+++ b/include/matter/concepts/destructible.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <type_traits>
+
+namespace matter
+{
+template<typename T>
+concept destructible = std::is_nothrow_destructible_v<T>;
+}

--- a/include/matter/concepts/equality_comparable.hpp
+++ b/include/matter/concepts/equality_comparable.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "matter/concepts/weakly_equality_comparable_with.hpp"
+
+namespace matter
+{
+template<typename T>
+concept equality_comparable = weakly_equality_comparable_with<T, T>;
+}

--- a/include/matter/concepts/floating_point.hpp
+++ b/include/matter/concepts/floating_point.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <type_traits>
+
+namespace matter
+{
+template<typename T>
+concept floating_point = std::is_floating_point_v<T>;
+}

--- a/include/matter/concepts/integral.hpp
+++ b/include/matter/concepts/integral.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <type_traits>
+
+namespace matter
+{
+template<typename T>
+concept integral = std::is_integral_v<T>;
+}

--- a/include/matter/concepts/invocable.hpp
+++ b/include/matter/concepts/invocable.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <functional>
+#include <utility>
+
+namespace matter
+{
+template<typename F, typename... Args>
+concept invocable = // clang-format off
+    requires(F&& fn, Args&&... args)
+    {
+        std::invoke(std::forward<F>(fn), std::forward<Args>(args)...);
+    }; // clang-format on
+} // namespace matter

--- a/include/matter/concepts/movable.hpp
+++ b/include/matter/concepts/movable.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "matter/concepts/assignable_from.hpp"
+#include "matter/concepts/move_constructible.hpp"
+
+namespace matter
+{
+template<typename T>
+concept movable =
+    std::is_object_v<T>&& move_constructible<T>&& assignable_from<T&, T>;
+// swappable<T>
+} // namespace matter

--- a/include/matter/concepts/move_constructible.hpp
+++ b/include/matter/concepts/move_constructible.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "matter/concepts/constructible_from.hpp"
+#include "matter/concepts/convertible_to.hpp"
+
+namespace matter
+{
+template<typename T>
+concept move_constructible = constructible_from<T, T>&& convertible_to<T, T>;
+}

--- a/include/matter/concepts/regular.hpp
+++ b/include/matter/concepts/regular.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "matter/concepts/equality_comparable.hpp"
+#include "matter/concepts/semiregular.hpp"
+
+namespace matter
+{
+template<typename T>
+concept regular = semiregular<T>&& equality_comparable<T>;
+}

--- a/include/matter/concepts/same_as.hpp
+++ b/include/matter/concepts/same_as.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <type_traits>
+
+namespace matter
+{
+template<typename T, typename U>
+concept same_as = std::is_same_v<T, U>&& std::is_same_v<U, T>;
+}

--- a/include/matter/concepts/semiregular.hpp
+++ b/include/matter/concepts/semiregular.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "matter/concepts/copyable.hpp"
+#include "matter/concepts/default_constructible.hpp"
+
+namespace matter
+{
+template<typename T>
+concept semiregular = copyable<T>&& default_constructible<T>;
+}

--- a/include/matter/concepts/signed_integral.hpp
+++ b/include/matter/concepts/signed_integral.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "matter/concepts/integral.hpp"
+
+namespace matter
+{
+template<typename T>
+concept signed_integral = matter::integral<T>&& std::is_signed_v<T>;
+}

--- a/include/matter/concepts/totally_ordered.hpp
+++ b/include/matter/concepts/totally_ordered.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "matter/concepts/boolean.hpp"
+#include "matter/concepts/equality_comparable.hpp"
+
+namespace matter
+{
+template<typename T>
+concept totally_ordered = // clang-format off
+    equality_comparable<T> &&
+    requires(const std::remove_reference_t<T>& a,
+             const std::remove_reference_t<T>& b)
+    {
+        { a <  b } -> boolean;
+        { a >  b } -> boolean;
+        { a <= b } -> boolean;
+        { a >= b } -> boolean;
+    }; // clang-format on
+} // namespace matter

--- a/include/matter/concepts/unsigned_integral.hpp
+++ b/include/matter/concepts/unsigned_integral.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "matter/concepts/signed_integral.hpp"
+
+namespace matter
+{
+template<typename T>
+concept unsigned_integral = integral<T> && !signed_integral<T>;
+}

--- a/include/matter/concepts/weakly_equality_comparable_with.hpp
+++ b/include/matter/concepts/weakly_equality_comparable_with.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "matter/concepts/boolean.hpp"
+
+namespace matter
+{
+template<typename T, typename U>
+concept weakly_equality_comparable_with = // clang-format off
+    requires (const std::remove_reference_t<T>& t,
+              const std::remove_reference_t<U>& u)
+    {
+        { t == u } -> boolean;
+        { t != u } -> boolean;
+        { u == t } -> boolean;
+        { u != t } -> boolean;
+    }; // clang-format on
+} // namespace matter

--- a/include/matter/container/concepts.hpp
+++ b/include/matter/container/concepts.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <utility>
+
+#include <hera/ranges.hpp>
+
+#include "matter/concepts/same_as.hpp"
+#include "matter/iterator/begin.hpp"
+#include "matter/iterator/end.hpp"
+#include "matter/ranges/size.hpp"
+#include "matter/ranges/traits.hpp"
+
+namespace matter
+{
+template<typename Cont, typename... Args>
+concept emplace_back_for = // clang-format off
+    requires(Cont& c, Args&&... args){
+        c.emplace_back(std::forward<Args>(args)...);
+    }; // clang-format on
+
+template<typename Cont, typename... Args>
+concept emplace_for = // clang-format off
+    requires(Cont& c, matter::iterator_t<Cont> p, Args&&... args)
+    {
+        c.emplace(p, std::forward<Args>(args)...);
+    }; // clang-format on
+
+template<typename Cont, typename T>
+concept push_back_for = // clang-format off
+    requires(Cont& c, T&& val)
+    {
+        c.push_back(std::forward<T>(val));
+    }; // clang-format on
+
+template<typename T, typename Cont>
+concept push_back_into = push_back_for<Cont, T>;
+
+template<typename Cont>
+concept reserveable = // clang-format off
+    requires(Cont& c, matter::range_size_t<Cont> sz)
+    {
+        c.reserve(sz);
+    }; // clang-format on
+
+template<typename Cont>
+concept shrinkable = // clang-format off
+    requires(Cont& c)
+    {
+        c.shrink_to_fit();
+    }; // clang-format on
+
+template<typename Cont>
+concept eraseable = // clang-format off
+    requires(Cont& c, iterator_t<Cont> it)
+    {
+        c.erase(it);
+        requires same_as<decltype(c.erase(it)), iterator_t<Cont>>;
+    }; // clang-format off
+} // namespace matter

--- a/include/matter/container/emplace_back.hpp
+++ b/include/matter/container/emplace_back.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <utility>
+
+#include "matter/ranges/traits.hpp"
+#include "matter/utility/priority_tag.hpp"
+
+namespace matter
+{
+namespace emplace_back_impl
+{
+template<typename C, typename... Args>
+constexpr auto emplace_back(priority_tag<4>, C& cont, Args&&... args) noexcept(
+    noexcept(cont.emplace_back(std::forward<Args>(args)...)))
+    -> decltype(cont.emplace_back(std::forward<Args>(args)...))
+{
+    return cont.emplace_back(std::forward<Args>(args)...);
+}
+
+template<typename C, typename... Args>
+constexpr auto emplace_back(priority_tag<3>, C& cont, Args&&... args) noexcept(
+    noexcept(emplace_back(cont, std::forward<Args>(args)...)))
+    -> decltype(emplace_back(cont, std::forward<Args>(args)...))
+{
+    return emplace_back(cont, std::forward<Args>(args)...);
+}
+
+template<typename C, typename U>
+constexpr auto emplace_back(priority_tag<2>, C& cont, U&& u) noexcept(
+    noexcept(cont.push_back(std::forward<U>(u))))
+    -> decltype(cont.push_back(std::forward<U>(u)))
+{
+    return cont.push_back(std::forward<U>(u));
+}
+
+template<typename C, typename... Args>
+constexpr auto emplace_back(priority_tag<1>, C& cont, Args&&... args) noexcept(
+    noexcept(cont.push_back(range_value_t<C>(std::forward<Args>(args)...))))
+    -> decltype(cont.push_back(range_value_t<C>(std::forward<Args>(args)...)))
+{
+    return cont.push_back(range_value_t<C>(std::forward<Args>(args)...));
+}
+} // namespace emplace_back_impl
+
+inline namespace cpo
+{
+struct emplace_back_fn
+{
+    template<typename C, typename... Args>
+    constexpr auto operator()(C& cont, Args&&... args) const noexcept(noexcept(
+        ::matter::emplace_back_impl::emplace_back(max_priority_tag,
+                                                  cont,
+                                                  std::forward<Args>(args)...)))
+        -> decltype(::matter::emplace_back_impl::emplace_back(
+            max_priority_tag,
+            cont,
+            std::forward<Args>(args)...))
+    {
+        return ::matter::emplace_back_impl::emplace_back(
+            max_priority_tag, cont, std::forward<Args>(args)...);
+    }
+};
+
+constexpr auto emplace_back = emplace_back_fn{};
+} // namespace cpo
+} // namespace matter

--- a/include/matter/container/erase_at.hpp
+++ b/include/matter/container/erase_at.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <utility>
+
+#include "matter/iterator/begin.hpp"
+#include "matter/iterator/concepts.hpp"
+#include "matter/ranges/traits.hpp"
+#include "matter/utility/priority_tag.hpp"
+
+namespace matter
+{
+namespace erase_at_impl
+{
+template<typename C>
+constexpr auto erase_at(priority_tag<4>, C& c, iterator_t<C> pos) noexcept(
+    noexcept(c.erase(std::move(pos)))) -> decltype(c.erase(std::move(pos)))
+{
+    return c.erase(std::move(pos));
+}
+
+template<typename C> // clang-format off
+    requires sized_sentinel_for<iterator_t<C>, iterator_t<C>> // clang-format on
+    constexpr auto erase_at(priority_tag<3>, C& c, iterator_t<C> pos) noexcept(
+        noexcept(c.erase(c,
+                         static_cast<range_size_t<C>>(pos - matter::begin(c)))))
+        -> decltype(
+            c.erase(c, static_cast<range_size_t<C>>(pos - matter::begin(c))))
+{
+    return c.erase(c, static_cast<range_size_t<C>>(pos - matter::begin(c)));
+}
+} // namespace erase_at_impl
+
+inline namespace cpo
+{
+struct erase_at_fn
+{
+    template<typename C>
+    constexpr auto operator()(C& c, iterator_t<C> pos) const noexcept(noexcept(
+        ::matter::erase_at_impl::erase_at(max_priority_tag, c, std::move(pos))))
+        -> decltype(::matter::erase_at_impl::erase_at(max_priority_tag,
+                                                      c,
+                                                      std::move(pos)))
+    {
+        return ::matter::erase_at_impl::erase_at(
+            max_priority_tag, c, std::move(pos));
+    }
+};
+
+// first tries to call .erase(it).
+// otherwise tries call .erase(it - begin) (attempt index erase) if the iterator
+// models sized_sentinel_for.
+constexpr auto erase_at = erase_at_fn{};
+} // namespace cpo
+} // namespace matter

--- a/include/matter/container/soa.hpp
+++ b/include/matter/container/soa.hpp
@@ -1,0 +1,320 @@
+#pragma once
+
+#include <cassert>
+#include <iterator>
+
+#include <hera/algorithm/for_each.hpp>
+#include <hera/algorithm/make_from_range.hpp>
+#include <hera/algorithm/unpack.hpp>
+#include <hera/container/pair.hpp>
+#include <hera/container/tuple.hpp>
+#include <hera/view/filter.hpp>
+#include <hera/view/transform.hpp>
+#include <hera/view/zip.hpp>
+
+#include "matter/concepts/default_constructible.hpp"
+#include "matter/concepts/same_as.hpp"
+#include "matter/container/concepts.hpp"
+#include "matter/container/erase_at.hpp"
+#include "matter/container/soa_iterator.hpp"
+#include "matter/container/soa_proxy.hpp"
+#include "matter/container/soa_sentinel.hpp"
+#include "matter/iterator/concepts.hpp"
+#include "matter/ranges/concepts.hpp"
+#include "matter/utility/decay_copy.hpp"
+
+namespace matter
+{
+namespace detail
+{
+namespace impl
+{
+template<typename... Ts>
+struct all_different_iter;
+
+template<typename T, typename U, typename... Ts>
+struct all_different_iter<T, U, Ts...>
+    : std::bool_constant<!matter::same_as<T, U> &&
+                         all_different_iter<T, Ts...>::value>
+{};
+
+template<typename T, typename U>
+struct all_different_iter<T, U> : std::bool_constant<!matter::same_as<T, U>>
+{};
+
+template<typename... Ts>
+struct all_different_start;
+
+template<typename T, typename U, typename... Ts>
+struct all_different_start<T, U, Ts...>
+    : std::conjunction<all_different_iter<T, U, Ts...>,
+                       all_different_start<U, Ts...>>
+{};
+
+template<typename T, typename U>
+struct all_different_start<T, U> : all_different_iter<T, U>
+{};
+
+template<typename T>
+struct all_different_start<T> : std::true_type
+{};
+} // namespace impl
+
+// TODO: make this quicker using hashes
+// this is very slow for now O(N^2) at compile time
+template<typename T, typename... Ts>
+concept all_different = impl::all_different_start<T, Ts...>::value;
+
+template<typename... Conts>
+constexpr bool all_containers_eraseable(hera::type_list<Conts...>) noexcept
+{
+    return (matter::eraseable<Conts> && ...);
+}
+} // namespace detail
+
+template<matter::sized_range... Containers> // clang-format off
+    requires(sizeof...(Containers) >= 1) && 
+        (std::is_object_v<Containers> && ...) // clang-format on
+    class soa {
+    static_assert(
+        (matter::same_as<Containers, std::remove_cvref_t<Containers>> && ...),
+        "All containers must be their base type");
+    static_assert(detail::all_different<range_value_t<Containers>...>,
+                  "All containers must hold a unique value_type");
+
+private:
+    using this_type                       = matter::soa<Containers...>;
+    static constexpr bool is_common_range = (common_range<Containers> && ...);
+
+public:
+    using size_type = matter::common_type_t<range_size_t<Containers>...>;
+
+private:
+    [[no_unique_address]] hera::tuple<Containers...> containers_;
+
+public:
+    soa() = default;
+
+    template<typename... UContainers> // clang-format off
+        requires sizeof...(UContainers) == sizeof...(Containers) &&
+            (matter::sized_range<UContainers> && ...) // gcc can't handle this in the template param
+            // https://godbolt.org/z/3MFk-z
+    constexpr soa(UContainers&&... containers) // clang-format on
+        noexcept(std::is_nothrow_constructible_v<hera::tuple<Containers...>,
+                                                 UContainers...>)
+        : containers_{std::forward<UContainers>(containers)...}
+    {
+        [[maybe_unused]] auto containers_same_size = [&] {
+            auto expected_size = matter::size(containers_.front());
+            bool sizes_match   = true;
+
+            // auto conts = only_containers(containers_);
+            hera::for_each(containers_, [&](auto& cont) {
+                if (expected_size != matter::size(cont))
+                {
+                    sizes_match = false;
+                }
+            });
+
+            return sizes_match;
+        };
+
+        assert(containers_same_size());
+    }
+
+    // check whether this soa contains the wanted value_type
+    template<typename T>
+    constexpr auto has_value_type() const noexcept
+    {
+        auto it = hera::find_if(containers_, [](const auto& container) {
+            return std::is_same<
+                T,
+                range_value_t<std::remove_cvref_t<decltype(container)>>>{};
+        });
+
+        return it != hera::end(containers_);
+    }
+
+private:
+    template<typename T> // clang-format off
+        //requires decltype(has_value_type<T>())::value
+    constexpr auto& container_for() noexcept // clang-format on
+    {
+        return *hera::find_if(containers_, [](auto& container) {
+            return std::is_same<
+                T,
+                range_value_t<std::remove_reference_t<decltype(container)>>>{};
+        });
+    }
+
+    template<typename T> // clang-format off
+        //requires decltype(has_value_type<T>())::value
+    constexpr const auto& container_for() const noexcept // clang-format on
+    {
+        return *hera::find_if(containers_, [](const auto& container) {
+            return std::is_same<
+                T,
+                range_value_t<std::remove_cvref_t<decltype(container)>>>{};
+        });
+    }
+
+public:
+    template<typename... Ts> // clang-format off
+        //requires (decltype(has_value_type<Ts>())::value && ...)
+    constexpr decltype(auto) begin(hera::type_identity<Ts>...) // clang-format on
+    {
+        if constexpr (sizeof...(Ts) == 0)
+        {
+            // delegate to ourselves
+            return begin(hera::type_identity<range_value_t<Containers>>{}...);
+        }
+        else
+        {
+            return soa_iterator{hera::type_identity<this_type>{},
+                                matter::begin(container_for<Ts>())...};
+        }
+    }
+
+    template<typename... Ts> // clang-format off
+        //requires (decltype(has_value_type<Ts>())::value && ...)
+    constexpr decltype(auto) end(hera::type_identity<Ts>...) const // clang-format on
+    {
+        if constexpr (sizeof...(Ts) == 0)
+        {
+            // delegate to ourselves
+            return end(hera::type_identity<range_value_t<Containers>>{}...);
+        }
+        else
+        {
+            if constexpr (is_common_range)
+            {
+                // common_ranges return soa_iterator
+                return soa_iterator{hera::type_identity<this_type>{},
+                                    matter::end(container_for<Ts>())...};
+            }
+            else
+            {
+                // and not common_ranges return soa_iterator
+                return soa_sentinel{hera::type_identity<this_type>{},
+                                    matter::end(container_for<Ts>())...};
+            }
+        }
+    }
+
+    constexpr size_type size() const noexcept
+    {
+        // just use the first size function we find
+        // possibly look for the first noexcept size function in the future.
+        return static_cast<size_type>(matter::size(containers_.front()));
+    }
+
+    constexpr bool empty() const noexcept
+    {
+        // just reuse size()
+        return size() == 0;
+    }
+
+    template<typename... Ts>
+    constexpr void push_back(Ts&&... vals)
+    {
+        // TODO: make this a constraint of the function once gcc accepts it
+        static_assert((matter::push_back_into<Ts, Containers> && ...));
+
+        hera::unpack(containers_, [&](auto&... conts) {
+            (conts.push_back(std::forward<Ts>(vals)), ...);
+        });
+    }
+
+    template<typename... Ts>
+    constexpr void push_back(const soa_proxy<Ts...>& val)
+    {}
+
+    template<typename... Ts>
+    constexpr void push_back(soa_proxy<Ts...>&& val)
+    {}
+
+private:
+    template<std::size_t I,
+             std::size_t... Is,
+             typename Tuple> // clang-format off
+        requires
+            requires(Tuple&& tup)
+            {
+                requires decltype(hera::size(tup))::value == sizeof...(Is); 
+            }
+    constexpr void emplace_back_one_impl(std::index_sequence<Is...>, // clang-format on
+        Tuple&&
+            tup) noexcept(noexcept(containers_
+                                       [std::integral_constant<std::size_t,
+                                                               I>{}]
+                                           .emplace_back(std::forward<Tuple>(
+                                               tup)[std::integral_constant<
+                                               std::size_t,
+                                               Is>{}]...)))
+    {
+        containers_[std::integral_constant<std::size_t, I>{}].emplace_back(
+            std::forward<Tuple>(
+                tup)[std::integral_constant<std::size_t, Is>{}]...);
+    }
+
+    template<std::size_t I, typename Tuple>
+    constexpr void
+    emplace_back_one(Tuple&& tup) noexcept(noexcept(emplace_back_one_impl<I>(
+        std::make_index_sequence<decltype(hera::size(tup))::value>{},
+        std::forward<Tuple>(tup))))
+    {
+        emplace_back_one_impl<I>(
+            std::make_index_sequence<decltype(hera::size(tup))::value>{},
+            std::forward<Tuple>(tup));
+    }
+
+    template<std::size_t... Is, typename... Tuples> // clang-format off
+        requires sizeof...(Containers) == sizeof...(Tuples) &&
+            sizeof...(Is) == sizeof...(Tuples)
+    constexpr void emplace_back_impl(std::index_sequence<Is...>, Tuples&&... tups) // clang-format on
+            noexcept(noexcept((emplace_back_one<Is>(std::forward<Tuples>(tups)),
+                               ...)))
+    {
+        (emplace_back_one<Is>(std::forward<Tuples>(tups)), ...);
+    }
+
+public:
+    template<typename... Tuples> // clang-format off
+        requires sizeof...(Containers) == sizeof...(Tuples)
+    constexpr void emplace_back(Tuples&&... tups) // clang-format on
+        noexcept(noexcept(
+            emplace_back_impl(std::make_index_sequence<sizeof...(Tuples)>{},
+                              std::forward<Tuples>(tups)...)))
+    {
+        // we can't simply use make_from_tuple because this would invoke a move.
+        // We want to forward all parameters from the tuple to the respective
+        // container's emplace_back method.
+        emplace_back_impl(std::make_index_sequence<sizeof...(Tuples)>{},
+                          std::forward<Tuples>(tups)...);
+    }
+
+    template<
+        typename ContList = hera::type_list<Containers...>> // clang-format off
+        requires
+            requires(ContList list)
+            {
+                detail::all_containers_eraseable(list);
+            }
+    constexpr soa_iterator<this_type, iterator_t<Containers>...>
+    erase(const soa_iterator<this_type, iterator_t<Containers>...>& pos) // clang-format on
+    {
+        return hera::unpack(
+            hera::zip_view{containers_, pos.iterators_},
+            [](auto&&... cont_it_pair) {
+                return soa_iterator<this_type,
+                                    iterator_t<Containers>...>{matter::erase_at(
+                    std::forward<decltype(cont_it_pair)>(cont_it_pair).front(),
+                    std::forward<decltype(cont_it_pair)>(cont_it_pair)
+                        .back())...};
+            });
+    }
+};
+
+template<typename... UContainers>
+soa(UContainers&&...)->soa<std::decay_t<UContainers>...>;
+} // namespace matter

--- a/include/matter/container/soa_iterator.hpp
+++ b/include/matter/container/soa_iterator.hpp
@@ -1,0 +1,343 @@
+#pragma once
+
+#include <hera/container/pair.hpp>
+
+#include "matter/concepts/totally_ordered.hpp"
+#include "matter/container/soa_proxy.hpp"
+#include "matter/iterator/concepts.hpp"
+#include "matter/iterator/iter_move.hpp"
+#include "matter/ranges/traits.hpp"
+
+namespace matter
+{
+namespace detail
+{
+template<typename... Is> // clang-format off
+    requires (matter::bidirectional_iterator<Is> && ...)
+constexpr void all_bidirectional_iterators(hera::type_list<Is...>) noexcept // clang-format on
+{}
+
+template<typename... Is> // clang-format off
+    requires (matter::random_access_iterator<Is> && ...)
+constexpr void all_random_access_iterators(hera::type_list<Is...>) noexcept // clang-format on
+{}
+
+template<typename... Is> // clang-format off
+    requires (matter::sized_sentinel_for<Is, Is> || ...)
+constexpr void any_sized_sentinel_for(hera::type_list<Is...>) noexcept // clang-format on
+{}
+
+template<typename... Is> // clang-format off
+    requires (matter::totally_ordered<Is> || ...)
+constexpr void any_totally_ordered(hera::type_list<Is...>) noexcept // clang-format on
+{}
+} // namespace detail
+
+template<typename SoA, typename... Its>
+class soa_iterator {
+private:
+    template<typename SoA_, typename... Its_>
+    friend class soa_sentinel;
+
+public:
+    using soa_type = SoA;
+
+    using value_type      = matter::soa_proxy<matter::iter_reference_t<Its>...>;
+    using reference       = value_type;
+    using pointer         = void;
+    using difference_type = matter::common_type_t<iter_difference_t<Its>...>;
+    using iterator_category = std::forward_iterator_tag;
+
+private:
+    [[no_unique_address]] hera::tuple<Its...> iterators_;
+
+public:
+    soa_iterator() = default;
+
+    constexpr soa_iterator(hera::type_identity<SoA>, Its... its) noexcept(
+        std::is_nothrow_constructible_v<hera::tuple<Its...>, Its...>)
+        : iterators_{std::move(its)...}
+    {}
+
+    constexpr soa_iterator(Its... its) noexcept(
+        std::is_nothrow_constructible_v<hera::tuple<Its...>, Its...>)
+        : iterators_{std::move(its)...}
+    {}
+
+    template<typename... UIts>
+    constexpr soa_iterator(const soa_iterator<SoA, UIts...>& other) noexcept(
+        std::is_nothrow_constructible_v<hera::tuple<Its...>,
+                                        const hera::tuple<Its...>&>)
+        : iterators_{other.iterators_}
+    {}
+
+    template<typename... UIts>
+    constexpr soa_iterator(soa_iterator<SoA, UIts...>&& other) noexcept(
+        std::is_nothrow_constructible_v<hera::tuple<Its...>,
+                                        hera::tuple<UIts...>&&>)
+        : iterators_{std::move(other.iterators_)}
+    {}
+
+    template<typename... UIts>
+    constexpr soa_iterator&
+    operator=(const soa_iterator<SoA, UIts...>& other) noexcept(
+        std::is_nothrow_assignable_v<hera::tuple<Its...>,
+                                     const hera::tuple<UIts...>&>)
+    {
+        iterators_ = other.iterators_;
+        return *this;
+    }
+
+    template<typename... UIts>
+    constexpr soa_iterator&
+    operator=(soa_iterator<SoA, UIts...>&& other) noexcept(
+        std::is_nothrow_assignable_v<hera::tuple<Its...>,
+                                     hera::tuple<UIts...>&&>)
+    {
+        iterators_ = std::move(other.iterators_);
+        return *this;
+    }
+
+    constexpr hera::tuple<Its...> base() const
+        noexcept(std::is_nothrow_copy_constructible_v<hera::tuple<Its...>>)
+    {
+        return iterators_;
+    }
+
+    constexpr bool operator==(const soa_iterator& other) const
+        noexcept(noexcept(iterators_.front() == other.iterators_.front()))
+    {
+        return iterators_.front() == other.iterators_.front();
+    }
+
+    constexpr bool operator!=(const soa_iterator& other) const
+        noexcept(noexcept(iterators_.front() != other.iterators_.front()))
+    {
+        return iterators_.front() != other.iterators_.front();
+    }
+
+private:
+    template<typename F,
+             typename ItList = hera::type_list<Its...>> // clang-format off
+        requires
+            requires(ItList list)
+            {
+                detail::any_totally_ordered(list);
+            } // clang-format on
+    constexpr bool generic_compare(const soa_iterator& other, F&& op) const
+    {
+        auto filtered_its =
+            hera::zip_view{iterators_, other.iterators_} |
+            hera::views::filter([](auto&& it_pair) {
+                using iterator_type =
+                    std::remove_cvref_t<decltype(it_pair.front())>;
+                return std::bool_constant<
+                    matter::totally_ordered<iterator_type>>{};
+            });
+
+        auto [it, other_it] = filtered_its.front();
+        return std::forward<F>(op)(it, other_it);
+    }
+
+public:
+    template<typename ItList = hera::type_list<Its...>> // clang-format off
+        requires
+            requires(ItList list)
+            {
+                detail::any_totally_ordered(list);
+            } // clang-format on
+    constexpr bool operator<(const soa_iterator& other) const
+    {
+        return generic_compare(other, [](const auto& it, const auto& other_it) {
+            return it < other_it;
+        });
+    }
+
+    template<typename ItList = hera::type_list<Its...>> // clang-format off
+        requires
+            requires(ItList list)
+            {
+                detail::any_totally_ordered(list);
+            } // clang-format on
+    constexpr bool operator<=(const soa_iterator& other) const
+    {
+        return generic_compare(other, [](const auto& it, const auto& other_it) {
+            return it <= other_it;
+        });
+    }
+
+    template<typename ItList = hera::type_list<Its...>> // clang-format off
+        requires
+            requires(ItList list)
+            {
+                detail::any_totally_ordered(list);
+            } // clang-format on
+    constexpr bool operator>(const soa_iterator& other) const
+    {
+        return generic_compare(other, [](const auto& it, const auto& other_it) {
+            return it > other_it;
+        });
+    }
+
+    template<typename ItList = hera::type_list<Its...>> // clang-format off
+        requires
+            requires(ItList list)
+            {
+                detail::any_totally_ordered(list);
+            } // clang-format on
+    constexpr bool operator>=(const soa_iterator& other) const
+    {
+        return generic_compare(other, [](const auto& it, const auto& other_it) {
+            return it >= other_it;
+        });
+    }
+
+    template<typename ItList = hera::type_list<Its...>> // clang-format off
+        requires
+            requires(ItList list)
+            {
+                detail::any_sized_sentinel_for(list);
+            } // clang-format on
+    constexpr difference_type operator-(const soa_iterator& other) const
+    {
+        auto filtered_its =
+            hera::zip_view{iterators_, other.iterators_} |
+            hera::views::filter([](auto&& it_pair) {
+                using iterator_type =
+                    std::remove_cvref_t<decltype(it_pair.front())>;
+                return std::bool_constant<
+                    matter::sized_sentinel_for<iterator_type, iterator_type>>{};
+            });
+
+        auto [it, other_it] = filtered_its.front();
+        return it - other_it;
+    }
+
+    constexpr soa_iterator& operator++() noexcept
+    {
+        hera::for_each(iterators_, [](auto& it) { ++it; });
+        return *this;
+    }
+
+    constexpr soa_iterator operator++(int) noexcept
+    {
+        auto res = *this;
+        ++(*this);
+        return res;
+    }
+
+    template<typename ItList = hera::type_list<Its...>> // clang-format off
+        requires
+            requires(ItList list)
+            {
+                detail::all_bidirectional_iterators(list);
+            } // clang-format on
+    constexpr soa_iterator& operator--() noexcept
+    {
+        hera::for_each(iterators_, [](auto& it) { --it; });
+        return *this;
+    }
+
+    template<typename ItList = hera::type_list<Its...>> // clang-format off
+        requires
+            requires(ItList list)
+            {
+                detail::all_bidirectional_iterators(list);
+            } // clang-format on
+    constexpr soa_iterator operator--(int) noexcept
+    {
+        auto res = *this;
+        --(*this);
+        return res;
+    }
+
+    template<typename ItList = hera::type_list<Its...>> // clang-format off
+        requires
+            requires(ItList list)
+            {
+                detail::all_random_access_iterators(list);
+            } // clang-format on
+    constexpr soa_iterator& operator+=(difference_type n)
+    {
+        hera::for_each(iterators_, [&](auto& it) { it += n; });
+        return *this;
+    }
+
+    template<typename ItList = hera::type_list<Its...>> // clang-format off
+        requires
+            requires(ItList list)
+            {
+                detail::all_random_access_iterators(list);
+            } // clang-format on
+    constexpr soa_iterator operator+(difference_type n) const
+    {
+        return hera::unpack(iterators_, [&](const auto&... its) {
+            return soa_iterator{(its + n)...};
+        });
+    }
+
+    template<typename ItList = hera::type_list<Its...>> // clang-format off
+        requires
+            requires(ItList list)
+            {
+                detail::all_random_access_iterators(list);
+            } // clang-format on
+    friend constexpr soa_iterator operator+(difference_type     n,
+                                            const soa_iterator& it)
+    {
+        return hera::unpack(it.iterators_, [&](const auto&... its) {
+            return soa_iterator{(n + its)...};
+        });
+    }
+
+    template<typename ItList = hera::type_list<Its...>> // clang-format off
+        requires
+            requires(ItList list)
+            {
+                detail::all_random_access_iterators(list);
+            } // clang-format on
+    constexpr soa_iterator operator-(difference_type n) const
+    {
+        return hera::unpack(iterators_, [&](const auto&... its) {
+            return soa_iterator{(its - n)...};
+        });
+    }
+
+    template<typename ItList = hera::type_list<Its...>> // clang-format off
+        requires
+            requires(ItList list)
+            {
+                detail::all_random_access_iterators(list);
+            } // clang-format on
+    constexpr soa_iterator& operator-=(difference_type n)
+    {
+        hera::for_each(iterators_, [&](auto& it) { it -= n; });
+        return *this;
+    }
+
+    friend constexpr auto iter_move(const soa_iterator& it)
+    {
+        return hera::unpack(it.iterators_, [](const auto&... its) {
+            return soa_proxy{matter::iter_move(its)...};
+        });
+    }
+
+    constexpr reference operator*() const
+    {
+        return hera::unpack(
+            iterators_, [](const auto&... its) { return reference{*its...}; });
+    }
+
+    template<typename ItList = hera::type_list<Its...>> // clang-format off
+        requires
+            requires(ItList list)
+            {
+                detail::all_random_access_iterators(list);
+            } // clang-format on
+    constexpr reference operator[](difference_type n) const
+        noexcept(noexcept(*(*this + n)))
+    {
+        return *(*this + n);
+    }
+};
+} // namespace matter

--- a/include/matter/container/soa_proxy.hpp
+++ b/include/matter/container/soa_proxy.hpp
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <utility>
+
+#include <hera/container/tuple.hpp>
+
+#include "matter/concepts/invocable.hpp"
+#include "matter/utility/common_reference.hpp"
+
+namespace matter
+{
+// a proxy stores and returns the Ts... in the signature
+// This class is purely meant to be destructured and is basically just a wrapper
+// around hera::tuple<Ts...>.
+template<typename... Ts>
+class soa_proxy {
+private:
+    hera::tuple<Ts...> values_;
+
+public:
+    constexpr soa_proxy(Ts... vals) noexcept
+        : values_{std::forward<Ts>(vals)...}
+    {}
+
+    template<typename... Us>
+    constexpr soa_proxy(const matter::soa_proxy<Us...>& other) noexcept(
+        std::is_nothrow_constructible_v<hera::tuple<Ts...>,
+                                        const hera::tuple<Us...>&>)
+        : values_{other.values_}
+    {}
+
+    template<typename... Us>
+    constexpr soa_proxy(matter::soa_proxy<Us...>&& other) noexcept(
+        std::is_nothrow_constructible_v<hera::tuple<Ts...>,
+                                        hera::tuple<Us...>&&>)
+        : values_{std::move(other.values_)}
+    {}
+
+    template<invocable<Ts...> F>
+    constexpr decltype(auto)
+    unpack(F&& fn) const& noexcept(std::is_nothrow_invocable_v<F, Ts...>)
+    {
+        return hera::unpack(values_, [&](auto&&... values) {
+            return std::invoke(std::forward<F>(fn),
+                               std::forward<decltype(values)>(values)...);
+        });
+    }
+
+    template<invocable<Ts...> F>
+    constexpr decltype(auto)
+    unpack(F&& fn) const&& noexcept(std::is_nothrow_invocable_v<F, Ts...>)
+    {
+        return hera::unpack(std::move(values_), [&](auto&&... values) {
+            return std::invoke(std::forward<F>(fn),
+                               std::forward<decltype(values)>(values)...);
+        });
+    }
+
+    template<std::size_t I> // clang-format off
+        requires (I < sizeof...(Ts)) // clang-format on
+        friend constexpr decltype(auto) get(soa_proxy& prox) noexcept
+    {
+        return prox.values_[std::integral_constant<std::size_t, I>{}];
+    }
+
+    template<std::size_t I> // clang-format off
+        requires (I < sizeof...(Ts)) // clang-format on
+        friend constexpr decltype(auto) get(const soa_proxy& prox) noexcept
+    {
+        return prox.values_[std::integral_constant<std::size_t, I>{}];
+    }
+
+    template<std::size_t I> // clang-format off
+        requires (I < sizeof...(Ts)) // clang-format on
+        friend constexpr decltype(auto) get(soa_proxy&& prox) noexcept
+    {
+        return std::move(
+            prox.values_)[std::integral_constant<std::size_t, I>{}];
+    }
+
+    template<std::size_t I> // clang-format off
+        requires (I < sizeof...(Ts)) // clang-format on
+        friend constexpr decltype(auto) get(const soa_proxy&& prox) noexcept
+    {
+        return std::move(
+            prox.values_)[std::integral_constant<std::size_t, I>{}];
+    }
+};
+
+// values should not get moved into the proxy, they will be forwarded through
+// it. Therefore not invoking any redundant move constructors or moving from
+// when not intended.
+template<typename... Ts>
+soa_proxy(Ts&&...)->soa_proxy<Ts&&...>;
+
+template<typename... Ts,
+         typename... Us,
+         template<typename>
+         typename TQual,
+         template<typename>
+         typename UQual>
+struct basic_common_reference<matter::soa_proxy<Ts...>,
+                              matter::soa_proxy<Us...>,
+                              TQual,
+                              UQual>
+{
+    using type = matter::soa_proxy<common_reference_t<TQual<Ts>, UQual<Us>>...>;
+};
+} // namespace matter
+
+namespace std
+{
+// proxy
+template<typename... Ts>
+struct tuple_size<matter::soa_proxy<Ts...>>
+    : std::integral_constant<std::size_t, sizeof...(Ts)>
+{};
+
+template<std::size_t I, typename... Ts> // clang-format off
+    requires (I < sizeof...(Ts))
+struct tuple_element<I, matter::soa_proxy<Ts...>> // clang-format on
+{
+    using type = std::tuple_element_t<I, std::tuple<Ts...>>;
+};
+} // namespace std

--- a/include/matter/container/soa_sentinel.hpp
+++ b/include/matter/container/soa_sentinel.hpp
@@ -1,0 +1,208 @@
+#pragma once
+
+#include <hera/view/filter.hpp>
+#include <hera/view/zip.hpp>
+
+#include "matter/iterator/concepts.hpp"
+#include "matter/iterator/traits.hpp"
+
+namespace matter
+{
+namespace detail
+{
+template<typename... Sents, typename... Its> // clang-format off
+    requires (sized_sentinel_for<Sents, Its> || ...)
+constexpr void any_sized_sentinel_for(hera::type_list<Sents...>, hera::type_list<Its...>) noexcept // clang-format on
+{}
+
+template<typename... Sents, typename... Its> // clang-format off
+    requires (sentinel_for<Sents, Its> && ...)
+constexpr void all_sentinel_for(hera::type_list<Sents...>, hera::type_list<Its...>) noexcept // clang-format on
+{}
+} // namespace detail
+
+template<typename SoA, typename... Sents>
+class soa_sentinel {
+public:
+    using soa_type = SoA;
+
+private:
+    [[no_unique_address]] hera::tuple<Sents...> sentinels_;
+
+public:
+    soa_sentinel() = default;
+
+    template<typename... USents>
+    constexpr soa_sentinel(
+        hera::type_identity<SoA>,
+        USents&&... sents) noexcept(std::
+                                        is_nothrow_constructible_v<
+                                            hera::tuple<Sents...>,
+                                            USents...>)
+        : sentinels_{std::forward<USents>(sents)...}
+    {}
+
+    template<typename... USents>
+    constexpr soa_sentinel(USents&&... sents) noexcept(
+        std::is_nothrow_constructible_v<hera::tuple<Sents...>, USents...>)
+        : sentinels_{std::forward<USents>(sents)...}
+    {}
+
+    template<typename... USents>
+    constexpr soa_sentinel(const soa_sentinel<SoA, USents...>& other) noexcept(
+        std::is_nothrow_constructible_v<hera::tuple<Sents...>,
+                                        const hera::tuple<USents...>>)
+        : sentinels_{other.sentinels_}
+    {}
+
+    template<typename... USents>
+    constexpr soa_sentinel(soa_sentinel<SoA, USents...>&& other) noexcept(
+        std::is_nothrow_constructible_v<hera::tuple<Sents...>,
+                                        hera::tuple<USents...>&&>)
+        : sentinels_{std::move(other.sentinels_)}
+    {}
+
+    template<typename... USents>
+    constexpr soa_sentinel&
+    operator=(const soa_sentinel<SoA, USents...>& other) noexcept(
+        std::is_nothrow_assignable_v<hera::tuple<Sents...>,
+                                     const hera::tuple<USents...>&>)
+    {
+        sentinels_ = other.sentinels_;
+        return *this;
+    }
+
+    template<typename... USents>
+    constexpr soa_sentinel&
+    operator=(soa_sentinel<SoA, USents...>&& other) noexcept(
+        std::is_nothrow_assignable_v<hera::tuple<Sents...>,
+                                     hera::tuple<USents...>&&>)
+    {
+        sentinels_ = std::move(other.sentinels_);
+    }
+
+    constexpr hera::tuple<Sents...> base() const
+        noexcept(std::is_nothrow_copy_constructible_v<hera::tuple<Sents...>>)
+    {
+        return sentinels_;
+    }
+
+    constexpr bool operator==(const soa_sentinel& other) const
+        noexcept(noexcept(sentinels_.first() == other.sentinels_.first()))
+    {
+        return sentinels_.first() == other.sentinels_.first();
+    }
+
+    constexpr bool operator!=(const soa_sentinel& other) const
+        noexcept(noexcept(sentinels_.first() != other.sentinels_.first()))
+    {
+        return sentinels_.first() != other.sentinels_.first();
+    }
+
+    template<typename... Its> // clang-format off
+        requires sizeof...(Its) == sizeof...(Sents) &&
+            requires(hera::type_list<Sents...> sent_tl, hera::type_list<Its...> it_tl)
+            {
+                detail::all_sentinel_for(sent_tl, it_tl);
+            } // clang-format on
+    constexpr bool operator==(const soa_iterator<SoA, Its...>& it) noexcept(
+        noexcept(sentinels_.first() == it.iterators_.first()))
+    {
+        return sentinels_.first() == it.iterators_.first();
+    }
+
+    template<typename... Its> // clang-format off
+        requires sizeof...(Its) == sizeof...(Sents) &&
+            requires(hera::type_list<Sents...> sent_tl, hera::type_list<Its...> it_tl)
+            {
+                detail::all_sentinel_for(sent_tl, it_tl);
+            } // clang-format on
+    constexpr bool operator!=(const soa_iterator<SoA, Its...>& it) noexcept(
+        noexcept(sentinels_.first() != it.iterators_.first()))
+    {
+        return sentinels_.first() != it.iterators_.first();
+    }
+
+    template<typename... Its> // clang-format off
+        requires sizeof...(Its) == sizeof...(Sents) &&
+            requires(hera::type_list<Sents...> sent_tl, hera::type_list<Its...> it_tl)
+            {
+                detail::all_sentinel_for(sent_tl, it_tl);
+            } // clang-format on
+    friend constexpr bool operator==(
+        const soa_iterator<SoA, Its...>& it,
+        const soa_sentinel& sent) noexcept(noexcept(it.iterators_.first() ==
+                                                    sent.sentinels_.first()))
+    {
+        return it.iterators_.first() == sent.sentinels_.first();
+    }
+
+    template<typename... Its> // clang-format off
+        requires sizeof...(Its) == sizeof...(Sents) &&
+            requires(hera::type_list<Sents...> sent_tl, hera::type_list<Its...> it_tl)
+            {
+                detail::all_sentinel_for(sent_tl, it_tl);
+            } // clang-format on
+    friend constexpr bool operator!=(
+        const soa_iterator<SoA, Its...>& it,
+        const soa_sentinel& sent) noexcept(noexcept(it.iterators_.first() !=
+                                                    sent.sentinels_.first()))
+    {
+        return it.iterators_.first() != sent.sentinels_.first();
+    }
+
+    template<typename... Its> // clang-format off
+        requires sizeof...(Its) == sizeof...(Sents) &&
+            requires(hera::type_list<Sents...> sent_tl, hera::type_list<Its...> it_tl)
+            {
+                detail::any_sized_sentinel_for(sent_tl, it_tl);
+            } // clang-format on
+    constexpr iter_difference_t<soa_iterator<SoA, Its...>>
+    operator-(const soa_iterator<SoA, Its...>& it) const
+    {
+        auto filtered_sents =
+            hera::zip_view{sentinels_, it.iterators_} |
+            hera::views::filter([](const auto& sent_it) {
+                using sentinel_type =
+                    std::remove_cvref_t<decltype(sent_it.front())>;
+                using iterator_type =
+                    std::remove_cvref_t<decltype(sent_it.back())>;
+
+                return std::bool_constant<
+                    matter::sized_sentinel_for<sentinel_type, iterator_type>>{};
+            });
+
+        auto [base_sent, base_it] = filtered_sents.front();
+        return base_sent - base_it;
+    }
+
+    template<typename... Its> // clang-format off
+        requires sizeof...(Its) == sizeof...(Sents) &&
+            requires(hera::type_list<Sents...> sent_tl, hera::type_list<Its...> it_tl)
+            {
+                detail::any_sized_sentinel_for(sent_tl, it_tl);
+            } // clang-format on
+    friend constexpr iter_difference_t<soa_iterator<SoA, Its...>>
+    operator-(const soa_iterator<SoA, Its...>& it, const soa_sentinel& sent)
+    {
+        auto filtered_sents =
+            hera::zip_view{sent.sentinels_, it.iterators_} |
+            hera::views::filter([](const auto& sent_it) {
+                using sentinel_type =
+                    std::remove_cvref_t<decltype(sent_it.front())>;
+                using iterator_type =
+                    std::remove_cvref_t<decltype(sent_it.back())>;
+
+                return std::bool_constant<
+                    matter::sized_sentinel_for<sentinel_type, iterator_type>>{};
+            });
+
+        auto [base_sent, base_it] = filtered_sents.front();
+        return base_it - base_sent;
+    }
+};
+
+template<typename SoA, typename... USents>
+soa_sentinel(hera::type_identity<SoA>, USents&&...)
+    ->soa_sentinel<SoA, std::decay_t<USents>...>;
+} // namespace matter

--- a/include/matter/container/traits.hpp
+++ b/include/matter/container/traits.hpp
@@ -1,0 +1,111 @@
+#pragma once
+
+#include "matter/container/size.hpp"
+#include "matter/iterator/begin.hpp"
+#include "matter/iterator/end.hpp"
+#include "matter/iterator/traits.hpp"
+
+namespace matter
+{
+namespace detail
+{
+template<typename C, typename = void>
+struct maybe_const_iterator
+{
+    using const_iterator = void;
+};
+
+template<typename C>
+struct maybe_const_iterator<C, std::void_t<matter::iterator_t<const C>>>
+{
+    using const_iterator = matter::iterator_t<const C>;
+};
+
+template<typename R, typename = void>
+struct is_sized : std::false_type
+{};
+
+template<typename R>
+struct is_sized<R, std::void_t<decltype(matter::size(std::declval<R&>()))>>
+    : std::true_type
+{};
+
+template<typename C, typename = void>
+struct has_shrink_to_fit : std::false_type
+{};
+
+template<typename C>
+struct has_shrink_to_fit<
+    C,
+    std::void_t<decltype(std::declval<C&>().shrink_to_fit())>> : std::true_type
+{};
+
+template<typename C, typename = void>
+struct has_reserve : std::false_type
+{};
+
+template<typename C>
+struct has_reserve<C,
+                   std::void_t<decltype(std::declval<C&>().reserve(
+                       std::declval<std::size_t>()))>> : std::true_type
+{};
+
+template<typename C, typename = void>
+struct has_front : std::false_type
+{};
+
+template<typename C>
+struct has_front<C, std::void_t<decltype(std::declval<C&>().front())>>
+    : std::true_type
+{};
+
+template<typename C, typename = void>
+struct has_back : std::false_type
+{};
+
+template<typename C>
+struct has_back<C, std::void_t<decltype(std::declval<C&>().back())>>
+    : std::true_type
+{};
+} // namespace detail
+
+template<typename C>
+struct container_traits : detail::maybe_const_iterator<C>
+{
+    using container_type = C;
+
+    using iterator = iterator_t<C>;
+    using sentinel = sentinel_t<C>;
+
+    using value_type      = range_value_t<C>;
+    using reference       = range_reference_t<C>;
+    using const_reference = range_reference_t<const C>;
+
+    static constexpr bool is_sized = detail::is_sized<C>::value;
+
+    static constexpr void reserve(
+        [[maybe_unused]] container_type& c,
+        [[maybe_unused]] std::size_t
+            new_capacity) noexcept(detail::has_reserve<container_type>::value ?
+                                       noexcept(c.reserve(new_capacity)) :
+                                       true)
+    {
+        if constexpr (detail::has_reserve<container_type>::value)
+        {
+            c.reserve(new_capacity);
+        }
+    }
+
+    static constexpr void
+    shrink_to_fit([[maybe_unused]] container_type& c) noexcept(
+        detail::has_shrink_to_fit<container_type>::value ?
+            noexcept(c.shrink_to_fit()) :
+            true)
+    {
+        if constexpr (detail::has_shrink_to_fit<container_type>::value)
+        {
+            c.shrink_to_fit();
+        }
+    }
+};
+} // namespace matter

--- a/include/matter/iterator/begin.hpp
+++ b/include/matter/iterator/begin.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <iterator>
+#include <utility>
+
+#include "matter/utility/decay_copy.hpp"
+#include "matter/utility/priority_tag.hpp"
+
+namespace matter
+{
+namespace begin_impl
+{
+template<typename R>
+void begin(R&&) = delete;
+
+template<typename T>
+void begin(std::initializer_list<T>&&) = delete;
+
+template<typename R>
+constexpr auto begin(priority_tag<2>,
+                     R& range) noexcept(noexcept(decay_copy(begin(range))))
+    -> decltype(decay_copy(begin(range)))
+{
+    return decay_copy(begin(range));
+}
+
+template<typename R>
+constexpr auto begin(priority_tag<3>,
+                     R& range) noexcept(noexcept(decay_copy(range.begin())))
+    -> decltype(decay_copy(range.begin()))
+{
+    return decay_copy(range.begin());
+}
+
+// implements: http://eel.is/c++draft/range.access.begin#1.1
+template<typename T, std::size_t N>
+constexpr auto begin(priority_tag<4>, T (&arr)[N]) noexcept(noexcept(arr + 0))
+    -> decltype(arr + 0)
+{
+    return arr + 0;
+}
+} // namespace begin_impl
+
+inline namespace cpo
+{
+struct begin_fn
+{
+    template<typename R>
+    constexpr auto operator()(R&& r) const
+        noexcept(noexcept(begin_impl::begin(max_priority_tag,
+                                            std::forward<R>(r))))
+            -> decltype(begin_impl::begin(max_priority_tag, std::forward<R>(r)))
+    {
+        return begin_impl::begin(max_priority_tag, std::forward<R>(r));
+    }
+};
+
+constexpr auto begin = begin_fn{};
+} // namespace cpo
+} // namespace matter

--- a/include/matter/iterator/common.hpp
+++ b/include/matter/iterator/common.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace matter
+{
+namespace detail
+{
+template<typename T>
+using with_reference = T&;
+}
+
+template<typename T>
+concept can_reference = // clang-format off
+    requires
+    {
+        typename detail::with_reference<T>;
+    }; // clang-format on
+
+template<typename T>
+concept dereferenceable = // clang-format off
+    requires (T& t) {
+        { *t } -> can_reference;
+    }; // clang-format on
+} // namespace matter

--- a/include/matter/iterator/concepts.hpp
+++ b/include/matter/iterator/concepts.hpp
@@ -1,0 +1,147 @@
+#pragma once
+
+#include "matter/concepts/common_reference_with.hpp"
+#include "matter/concepts/default_constructible.hpp"
+#include "matter/concepts/regular.hpp"
+#include "matter/concepts/same_as.hpp"
+#include "matter/concepts/semiregular.hpp"
+#include "matter/concepts/signed_integral.hpp"
+#include "matter/concepts/totally_ordered.hpp"
+#include "matter/concepts/weakly_equality_comparable_with.hpp"
+#include "matter/iterator/common.hpp"
+#include "matter/iterator/traits.hpp"
+
+namespace matter
+{
+namespace detail
+{
+template<typename T>
+constexpr bool is_signed_integer_like = signed_integral<T>;
+// TODO http://eel.is/c++draft/iterators#iterator.concept.winc-2 to model
+// integer-class type.
+} // namespace detail
+
+template<typename I>
+concept weakly_incrementable = // clang-format off
+    matter::default_constructible<I>&&
+    matter::movable<I>&& 
+    requires(I i)
+    {
+        typename matter::iter_difference_t<I>;
+        requires detail::is_signed_integer_like<matter::iter_difference_t<I>>;
+        { ++i };
+        requires same_as<decltype(++i), I&>;
+        i++;
+    }; // clang-format on
+
+template<typename I>
+concept incrementable = // clang-format off
+    regular<I> &&
+    weakly_incrementable<I> &&
+    requires(I i)
+    {
+        { i++ } -> same_as<I>;
+    }; // clang-format on
+
+template<typename I>
+concept input_or_output_iterator = // clang-format off
+    requires(I i)
+    {
+        { *i } -> can_reference;
+    } && weakly_incrementable<I>; // clang-format on
+
+template<typename In>
+concept readable = // clang-format off
+    requires
+    {
+        typename iter_value_t<In>;
+        typename iter_reference_t<In>;
+        typename iter_rvalue_reference_t<In>;
+    } &&
+    common_reference_with<iter_reference_t<In>&&, iter_value_t<In>&> &&
+    common_reference_with<iter_reference_t<In>&&, iter_rvalue_reference_t<In>&&> &&
+    common_reference_with<iter_rvalue_reference_t<In>&&, const iter_value_t<In>&>; // clang-format on
+
+template<typename Out, typename T>
+concept writable = // clang-format off
+    requires(Out&& o, T&& t)
+    {
+        *o = std::forward<T>(t);
+        *std::forward<Out>(o) = std::forward<T>(t);
+        const_cast<const iter_reference_t<Out>&&>(*o) =
+            std::forward<T>(t);
+        const_cast<const iter_reference_t<Out>&&>(*std::forward<Out>(o)) =
+            std::forward<T>(t);
+    }; // clang-format on
+
+template<typename I>
+concept input_iterator = // clang-format off
+    input_or_output_iterator<I> &&
+    readable<I>; // clang-format on
+// consciously leaving out the iterator_traits stuff
+
+template<typename I, typename T>
+concept output_iterator = // clang-format off
+    input_or_output_iterator<I> &&
+    writable<I, T> &&
+    requires(I i, T&& t)
+    {
+        *i++ = std::forward<T>(t);
+    }; // clang-format on
+
+template<typename S, typename I>
+concept sentinel_for = semiregular<S>&& input_or_output_iterator<I>&&
+                                        weakly_equality_comparable_with<S, I>;
+
+template<typename S, typename I>
+inline constexpr bool disable_sized_sentinel_for = false;
+
+template<typename S, typename I>
+concept sized_sentinel_for =
+    sentinel_for<S, I> &&
+    !disable_sized_sentinel_for<std::remove_cv_t<S>,
+                                std::remove_cv_t<I>> && // clang-format off
+    requires(const I& i, const S& s)
+    {
+        { s - i } -> same_as<iter_difference_t<I>>;
+        { i - s } -> same_as<iter_difference_t<I>>;
+    }; // clang-format on
+
+template<typename I>
+concept forward_iterator = // clang-format off
+    input_iterator<I> &&
+    incrementable<I> &&
+    sentinel_for<I, I>; // clang-format on
+
+template<typename I>
+concept bidirectional_iterator = // clang-format off
+    forward_iterator<I> &&
+    requires(I i)
+    {
+        { --i };
+        requires same_as<decltype(--i), I&>;
+        { i-- };
+        requires same_as<decltype(i--), I>;
+    }; // clang-format on
+
+template<typename I>
+concept random_access_iterator = // clang-format off
+    bidirectional_iterator<I> &&
+    totally_ordered<I> &&
+    sized_sentinel_for<I, I> &&
+    requires(I i, const I j, const iter_difference_t<I> n)
+    {
+        { i += n };
+        requires same_as<decltype(i += n), I&>;
+        { j +  n };
+        requires same_as<decltype(j + n), I>;
+        { n +  j };
+        requires same_as<decltype(n + j), I>;
+        { i -= n };
+        requires same_as<decltype(i -= n), I&>;
+        { j -  n };
+        requires same_as<decltype(j - n), I>;
+        { j[n] };
+        requires same_as<decltype(j[n]), iter_reference_t<I>>;
+    };
+} // namespace matter

--- a/include/matter/iterator/end.hpp
+++ b/include/matter/iterator/end.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <iterator>
+#include <utility>
+
+#include "matter/utility/decay_copy.hpp"
+#include "matter/utility/priority_tag.hpp"
+
+namespace matter
+{
+namespace end_impl
+{
+template<typename R>
+constexpr auto end(R&&) = delete;
+
+template<typename T>
+constexpr auto end(std::initializer_list<T>&&) = delete;
+
+template<typename R>
+constexpr auto end(priority_tag<2>,
+                   R& range) noexcept(noexcept(decay_copy(end(range))))
+    -> decltype(decay_copy(end(range)))
+{
+    return decay_copy(end(range));
+}
+
+template<typename R>
+constexpr auto end(priority_tag<3>,
+                   R& range) noexcept(noexcept(decay_copy(range.end())))
+    -> decltype(decay_copy(range.end()))
+{
+    return decay_copy(range.end());
+}
+
+template<typename T, std::size_t N>
+constexpr auto end(priority_tag<4>, T (&arr)[N]) noexcept(noexcept(arr + N))
+    -> decltype(arr + N)
+{
+    return arr + N;
+}
+} // namespace end_impl
+
+inline namespace cpo
+{
+struct end_fn
+{
+    template<typename R>
+    constexpr auto operator()(R&& r) const
+        noexcept(noexcept(end_impl::end(max_priority_tag, std::forward<R>(r))))
+            -> decltype(end_impl::end(max_priority_tag, std::forward<R>(r)))
+    {
+        return end_impl::end(max_priority_tag, std::forward<R>(r));
+    }
+};
+
+constexpr auto end = end_fn{};
+} // namespace cpo
+} // namespace matter

--- a/include/matter/iterator/iter_move.hpp
+++ b/include/matter/iterator/iter_move.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <utility>
+
+#include "matter/utility/priority_tag.hpp"
+
+namespace matter
+{
+namespace iter_move_impl
+{
+template<typename I>
+constexpr auto
+    iter_move(priority_tag<4>,
+              I&& it) noexcept(noexcept(iter_move(std::forward<I>(it))))
+        -> decltype(iter_move(std::forward<I>(it)))
+{
+    return iter_move(std::forward<I>(it));
+}
+
+template<typename I> // clang-format off
+    requires
+        requires(I&& it)
+        {
+            requires std::is_lvalue_reference_v<decltype(*std::forward<I>(it))>;
+        } // clang-format on
+constexpr auto
+    iter_move(priority_tag<3>,
+              I&& it) noexcept(noexcept(std::move(*std::forward<I>(it))))
+        -> decltype(std::move(*std::forward<I>(it)))
+{
+    return std::move(*std::forward<I>(it));
+}
+
+template<typename I> // clang-format off
+    requires
+        requires(I&& it)
+        {
+            requires !std::is_lvalue_reference_v<decltype(*std::forward<I>(it))>;
+        }
+constexpr auto // clang-format on
+    iter_move(priority_tag<3>, I&& it) noexcept(noexcept(*std::forward<I>(it)))
+        -> decltype(*std::forward<I>(it))
+{
+    return *std::forward<I>(it);
+}
+} // namespace iter_move_impl
+
+inline namespace cpo
+{
+struct iter_move_fn
+{
+    template<typename I>
+    constexpr auto operator()(I&& it) const noexcept(
+        noexcept(::matter::iter_move_impl::iter_move(max_priority_tag,
+                                                     std::forward<I>(it))))
+        -> decltype(::matter::iter_move_impl::iter_move(max_priority_tag,
+                                                        std::forward<I>(it)))
+    {
+        return ::matter::iter_move_impl::iter_move(max_priority_tag,
+                                                   std::forward<I>(it));
+    }
+};
+
+constexpr auto iter_move = iter_move_fn{};
+} // namespace cpo
+} // namespace matter

--- a/include/matter/iterator/traits.hpp
+++ b/include/matter/iterator/traits.hpp
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <iterator>
+#include <type_traits>
+
+#include "matter/iterator/common.hpp"
+#include "matter/iterator/iter_move.hpp"
+
+namespace matter
+{
+namespace detail
+{
+template<typename T, typename = void>
+struct cond_value_type
+{};
+
+template<typename T>
+struct cond_value_type<T, std::enable_if_t<std::is_object_v<T>>>
+{
+    using value_type = std::remove_cv_t<T>;
+};
+
+template<typename T, typename = void>
+struct has_value_type : std::false_type
+{};
+
+template<typename T>
+struct has_value_type<T, std::void_t<typename T::value_type>> : std::true_type
+{};
+
+template<typename T, typename = void>
+struct has_element_type : std::false_type
+{};
+
+template<typename T>
+struct has_element_type<T, std::void_t<typename T::element_type>>
+    : std::true_type
+{};
+} // namespace detail
+
+template<typename T, typename = void>
+struct readable_traits
+{};
+
+template<typename T>
+struct readable_traits<T*, void> : detail::cond_value_type<T>
+{};
+
+template<typename T>
+struct readable_traits<T, std::enable_if_t<std::is_array_v<T>>>
+{
+    using value_type = std::remove_cv_t<std::remove_extent_t<T>>;
+};
+
+template<typename T>
+struct readable_traits<const T, void> : readable_traits<T, void>
+{};
+
+template<typename T>
+struct readable_traits<T, std::enable_if_t<detail::has_value_type<T>::value>>
+    : detail::cond_value_type<typename T::value_type>
+{};
+
+template<typename T>
+struct readable_traits<T, std::enable_if_t<detail::has_element_type<T>::value>>
+    : detail::cond_value_type<typename T::element_type>
+{};
+
+namespace detail
+{
+template<typename I, typename = void>
+struct iter_value
+{
+    using type = typename std::iterator_traits<I>::value_type;
+};
+
+template<typename I>
+struct iter_value<
+    I,
+    std::enable_if_t<detail::has_value_type<matter::readable_traits<I>>::value>>
+{
+    using type = typename matter::readable_traits<I>::value_type;
+};
+} // namespace detail
+
+template<typename I>
+using iter_value_t = typename detail::iter_value<I>::type;
+
+namespace detail
+{
+template<typename I, typename = void>
+struct iter_reference;
+
+template<typename I>
+struct iter_reference<I, std::enable_if_t<matter::dereferenceable<I>>>
+{
+    using type = decltype(*std::declval<I&>());
+};
+} // namespace detail
+
+template<typename I>
+using iter_reference_t = typename detail::iter_reference<I>::type;
+
+template<typename I>
+using iter_difference_t = typename std::iterator_traits<I>::difference_type;
+
+namespace detail
+{
+template<typename I, typename = void>
+struct iter_rvalue_reference;
+
+template<typename I>
+struct iter_rvalue_reference<
+    I,
+    std::enable_if_t<
+        matter::dereferenceable<I> &&
+        can_reference<decltype(matter::iter_move(std::declval<I&>()))>>>
+{
+    using type = decltype(matter::iter_move(std::declval<I&>()));
+};
+} // namespace detail
+
+template<typename I>
+using iter_rvalue_reference_t = typename detail::iter_rvalue_reference<I>::type;
+} // namespace matter

--- a/include/matter/ranges/concepts.hpp
+++ b/include/matter/ranges/concepts.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <utility>
+
+#include "matter/concepts/same_as.hpp"
+#include "matter/iterator/begin.hpp"
+#include "matter/iterator/end.hpp"
+#include "matter/iterator/traits.hpp"
+#include "matter/ranges/size.hpp"
+
+namespace matter
+{
+namespace detail
+{
+template<typename R>
+concept range_impl = // clang-format off
+    requires(R&& r)
+    {
+        matter::begin(std::forward<R>(r));
+        matter::end(std::forward<R>(r));
+    }; // clang-format on
+} // namespace detail
+
+template<typename R>
+concept range = detail::range_impl<R&>;
+
+template<typename R>
+concept sized_range = // clang-format off
+    range<R>&& 
+        requires(R& r)
+        {
+            matter::size(r);
+        }; // clang-format on
+
+template<typename R>
+concept common_range = // clang-format off
+    range<R> && same_as<iterator_t<R>, sentinel_t<R>>;
+} // namespace matter

--- a/include/matter/ranges/front_back.hpp
+++ b/include/matter/ranges/front_back.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <utility>
+
+#include "matter/iterator/begin.hpp"
+#include "matter/iterator/end.hpp"
+#include "matter/ranges/concepts.hpp"
+#include "matter/ranges/size.hpp"
+#include "matter/utility/priority_tag.hpp"
+
+namespace matter
+{
+namespace front_impl
+{
+template<typename T, std::size_t N>
+constexpr auto front(priority_tag<4>,
+                     T (&arr)[N]) noexcept(noexcept(*(arr + 0)))
+    -> decltype(*(arr + 0))
+{
+    return *(arr + 0);
+}
+
+template<typename R>
+constexpr auto front(priority_tag<3>, R& r) noexcept(noexcept(r.front()))
+    -> decltype(r.front())
+{
+    return r.front();
+}
+
+template<typename R>
+constexpr auto front(priority_tag<2>, R& r) noexcept(noexcept(front(r)))
+    -> decltype(front(r))
+{
+    return front(r);
+}
+
+template<typename R>
+constexpr auto front(priority_tag<1>,
+                     R& r) noexcept(noexcept(*matter::begin(r)))
+    -> decltype(*matter::begin(r))
+{
+    return *matter::begin(r);
+}
+} // namespace front_impl
+
+inline namespace cpo
+{
+constexpr auto front = [](auto&& range) noexcept(noexcept(
+    ::matter::front_impl::front(max_priority_tag,
+                                std::forward<decltype(range)>(range))))
+                           -> decltype(::matter::front_impl::front(
+                               max_priority_tag,
+                               std::forward<decltype(range)>(range)))
+{
+    return ::matter::front_impl::front(max_priority_tag,
+                                       std::forward<decltype(range)>(range));
+};
+} // namespace cpo
+
+namespace back_impl
+{
+template<typename T, std::size_t N>
+constexpr auto
+    back(priority_tag<4>,
+         T (&arr)[N]) noexcept(noexcept(*(arr + (std::extent_v<T[N]> - 1))))
+        -> decltype(*(arr + (std::extent_v<T[N]> - 1)))
+{
+    return *(arr + (std::extent_v<T[N]> - 1));
+}
+
+template<typename R>
+constexpr auto back(priority_tag<3>, R& r) noexcept(noexcept(r.back()))
+    -> decltype(r.back())
+{
+    return r.back();
+}
+
+// customization point for back function
+template<typename R>
+constexpr auto back(priority_tag<2>, R& r) noexcept(noexcept(back(r)))
+    -> decltype(back(r))
+{
+    return back(r);
+}
+
+// try going one back from the past the end iterator
+template<typename R> // clang-format off
+requires bidirectional_range<R> && common_range<R>
+constexpr auto back(priority_tag<1>, // clang-format on
+         R& r) noexcept(noexcept(*(--matter::end(r))))
+        -> decltype(*(--matter::end(r)))
+{
+    return *(--matter::end(r));
+}
+
+// only activated in case end iterator is not decrementable (for example with
+// sentinels)
+template<typename R> // clang-format off
+    requires random_access_range<R> && sized_range<R>
+constexpr auto // clang-format on
+        back(priority_tag<0>, R& r) noexcept(noexcept(*(matter::begin(r) +
+                                                        (matter::size(r) - 1))))
+            -> decltype(*(matter::begin(r) + (matter::size(r) - 1)))
+{
+    return *(matter::begin(r) + (matter::size(r) - 1));
+}
+} // namespace back_impl
+
+inline namespace cpo
+{
+constexpr auto back = [](auto&& range) noexcept(noexcept(
+    ::matter::back_impl::back(max_priority_tag,
+                              std::forward<decltype(range)>(range))))
+                          -> decltype(::matter::back_impl::back(
+                              max_priority_tag,
+                              std::forward<decltype(range)>(range)))
+{
+    return ::matter::back_impl::back(max_priority_tag,
+                                     std::forward<decltype(range)>(range));
+};
+} // namespace cpo
+} // namespace matter

--- a/include/matter/ranges/size.hpp
+++ b/include/matter/ranges/size.hpp
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <type_traits>
+
+#include "matter/iterator/begin.hpp"
+#include "matter/iterator/end.hpp"
+#include "matter/utility/decay_copy.hpp"
+#include "matter/utility/priority_tag.hpp"
+
+namespace matter
+{
+namespace size_impl
+{
+template<typename I, typename = void>
+struct is_integer_like : std::false_type
+{};
+
+// not a complete definition of integer-like, see
+// http://eel.is/c++draft/iterator.concept.winc for a correct implementation.
+template<typename I>
+struct is_integer_like<I, std::enable_if_t<std::is_integral_v<I>>>
+    : std::true_type
+{};
+
+template<typename T, std::size_t N>
+constexpr auto
+    size(priority_tag<4>,
+         T (&arr)[N]) noexcept(noexcept(decay_copy(std::extent_v<T[N]>)))
+        -> decltype(decay_copy(std::extent_v<T[N]>))
+{
+    return decay_copy(std::extent_v<T[N]>);
+}
+
+template<typename R>
+constexpr auto size(priority_tag<3>, R&& r) noexcept(
+    noexcept(decay_copy(std::forward<R>(r).size())))
+    -> std::enable_if_t<
+        is_integer_like<decltype(decay_copy(std::forward<R>(r).size()))>::value,
+        decltype(decay_copy(std::forward<R>(r).size()))>
+{
+    return decay_copy(std::forward<R>(r).size());
+}
+
+// needs to be in scope for the following
+template<typename T>
+void size(T&&) = delete;
+
+template<typename R>
+constexpr auto size(priority_tag<2>, R&& r) noexcept(
+    noexcept(decay_copy(size(std::forward<R>(r)))))
+    -> std::enable_if_t<
+        is_integer_like<decltype(decay_copy(size(std::forward<R>(r))))>::value,
+        decltype(decay_copy(size(std::forward<R>(r))))>
+{
+    return decay_copy(size(std::forward<R>(r)));
+}
+
+template<typename R>
+using _size_type =
+    decltype(decay_copy(matter::end(std::declval<R>() - std::declval<R>())));
+
+template<typename R>
+constexpr auto size(priority_tag<1>, R&& r) noexcept(
+    noexcept(std::make_unsigned_t<_size_type<R>>{decay_copy(
+        matter::end(std::forward<R>(r)) - matter::begin(std::forward<R>(r)))}))
+    -> decltype(std::make_unsigned_t<_size_type<R>>{decay_copy(
+        matter::end(std::forward<R>(r)) - matter::begin(std::forward<R>(r)))})
+{
+    return std::make_unsigned_t<_size_type<R>>{decay_copy(
+        matter::end(std::forward<R>(r)) - matter::begin(std::forward<R>(r)))};
+}
+} // namespace size_impl
+
+inline namespace cpo
+{
+constexpr auto size = [](auto&& range) noexcept(noexcept(
+    ::matter::size_impl::size(max_priority_tag,
+                              std::forward<decltype(range)>(range))))
+                          -> decltype(::matter::size_impl::size(
+                              max_priority_tag,
+                              std::forward<decltype(range)>(range)))
+{
+    return ::matter::size_impl::size(max_priority_tag,
+                                     std::forward<decltype(range)>(range));
+};
+} // namespace cpo
+} // namespace matter

--- a/include/matter/ranges/traits.hpp
+++ b/include/matter/ranges/traits.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "matter/iterator/begin.hpp"
+#include "matter/iterator/end.hpp"
+#include "matter/iterator/traits.hpp"
+#include "matter/ranges/size.hpp"
+
+namespace matter
+{
+template<typename R>
+using iterator_t = decltype(matter::begin(std::declval<R&>()));
+
+template<typename R>
+using sentinel_t = decltype(matter::end(std::declval<R&>()));
+
+template<typename R>
+using range_value_t = iter_value_t<iterator_t<R>>;
+
+template<typename R>
+using range_reference_t = iter_reference_t<iterator_t<R>>;
+
+template<typename R>
+using range_rvalue_reference_t = iter_rvalue_reference_t<iterator_t<R>>;
+
+template<typename R>
+using range_size_t = decltype(matter::size(std::declval<R&>()));
+} // namespace matter

--- a/include/matter/utility/common_reference.hpp
+++ b/include/matter/utility/common_reference.hpp
@@ -1,0 +1,240 @@
+#pragma once
+
+#include <type_traits>
+
+// copied from hera::common_reference which is copied from clang's
+// common_reference. Originally by Casey Carter.
+namespace matter
+{
+template<typename T,
+         typename U,
+         template<typename>
+         typename TQual,
+         template<typename>
+         typename UQual>
+struct basic_common_reference
+{};
+
+namespace detail
+{
+template<typename T, typename U>
+using cond_res =
+    decltype(false ? std::declval<T (&)()>()() : std::declval<U (&)()>()());
+
+template<typename T, typename U, typename = void>
+struct common_type3
+{};
+
+template<typename T>
+using cref = std::add_lvalue_reference_t<const T>;
+
+template<typename T, typename U>
+struct common_type3<T, U, std::void_t<cond_res<cref<T>, cref<U>>>>
+{
+    using type = std::decay_t<cond_res<cref<T>, cref<U>>>;
+};
+
+template<typename T, typename U>
+struct common_type2 : common_type3<T, U>
+{};
+} // namespace detail
+
+template<typename... Ts>
+struct common_type;
+
+template<>
+struct common_type<>
+{};
+
+template<typename T>
+struct common_type<T> : common_type<T, T>
+{};
+
+template<typename T, typename U>
+struct common_type<T, U>
+    : std::conditional_t<std::is_same_v<T, std::decay_t<T>> &&
+                             std::is_same_v<U, std::decay_t<U>>,
+                         detail::common_type2<T, U>,
+                         common_type<std::decay_t<T>, std::decay_t<U>>>
+{};
+
+template<typename... Ts>
+using common_type_t = typename common_type<Ts...>::type;
+
+template<typename T, typename U, typename V, typename... Rest>
+struct common_type<T, U, V, Rest...>
+    : common_type<common_type_t<T, U>, V, Rest...>
+{};
+
+namespace detail
+{
+template<typename T>
+struct copy_cv_
+{
+    template<typename U>
+    using fn = U;
+};
+
+template<typename T>
+struct copy_cv_<const T>
+{
+    template<typename U>
+    using fn = std::add_const_t<U>;
+};
+
+template<typename T>
+struct copy_cv_<volatile T>
+{
+    template<typename U>
+    using fn = std::add_volatile_t<U>;
+};
+
+template<typename T>
+struct copy_cv_<const volatile T>
+{
+    template<typename U>
+    using fn = std::add_cv_t<U>;
+};
+
+template<typename From, typename To>
+using copy_cv = typename copy_cv_<From>::template fn<To>;
+
+template<typename T>
+struct xref
+{
+    template<typename U>
+    using fn = copy_cv<T, U>;
+};
+
+template<typename T>
+struct xref<T&>
+{
+    template<typename U>
+    using fn = std::add_lvalue_reference_t<copy_cv<T, U>>;
+};
+
+template<typename T>
+struct xref<T&&>
+{
+    template<typename U>
+    using fn = std::add_rvalue_reference_t<copy_cv<T, U>>;
+};
+
+template<typename T,
+         typename U,
+         typename Result = cond_res<copy_cv<T, U>&, copy_cv<U, T>&>,
+         typename        = std::enable_if_t<std::is_lvalue_reference_v<Result>>>
+using ll_common_ref = Result;
+
+template<typename T, typename U>
+using rr_common_ref = std::remove_reference_t<ll_common_ref<T, U>>&&;
+} // namespace detail
+
+template<typename...>
+struct common_reference
+{};
+
+template<typename T>
+struct common_reference<T>
+{
+    using type = T;
+};
+
+namespace detail
+{
+template<typename T, typename U, typename = void>
+struct common_reference4 : hera::common_type<T, U>
+{};
+
+template<typename T, typename U>
+struct common_reference4<T, U, std::void_t<cond_res<T, U>>>
+{
+    using type = cond_res<T, U>;
+};
+
+template<typename T, typename U>
+using basic_common_ref =
+    typename basic_common_reference<std::remove_cvref_t<T>,
+                                    std::remove_cvref_t<U>,
+                                    xref<T>::template fn,
+                                    xref<U>::template fn>::type;
+
+template<typename T, typename U, typename = void>
+struct common_reference3 : common_reference4<T, U>
+{};
+
+template<typename T, typename U>
+struct common_reference3<T, U, std::void_t<basic_common_ref<T, U>>>
+{
+    using type = basic_common_ref<T, U>;
+};
+
+template<typename T, typename U, typename = void>
+struct common_reference2 : common_reference3<T, U>
+{};
+
+template<typename T, typename U>
+struct common_reference2<T&, U&, std::void_t<ll_common_ref<T, U>>>
+{
+    using type = ll_common_ref<T, U>;
+};
+
+template<typename T, typename U>
+struct common_reference2<
+    T&&,
+    U&,
+    std::enable_if_t<std::is_convertible_v<T&&, ll_common_ref<const T, U>>>>
+{
+    using type = ll_common_ref<const T, U>;
+};
+
+template<typename T, typename U>
+struct common_reference2<
+    T&,
+    U&&,
+    std::enable_if_t<std::is_convertible_v<U&&, ll_common_ref<const U, T>>>>
+{
+    using type = ll_common_ref<const U, T>;
+};
+
+template<typename T, typename U>
+struct common_reference2<
+    T&&,
+    U&&,
+    std::enable_if_t<std::is_convertible_v<T&&, rr_common_ref<T, U>> &&
+                     std::is_convertible_v<U&&, rr_common_ref<T, U>>>>
+{
+    using type = rr_common_ref<T, U>;
+};
+} // namespace detail
+
+template<typename... Ts>
+struct common_reference;
+
+template<typename T, typename U>
+struct common_reference<T, U> : detail::common_reference2<T, U>
+{};
+
+namespace detail
+{
+template<typename Void, typename T, typename U, typename... Ts>
+struct fold_common_reference
+{};
+
+template<typename T, typename U, typename... Ts>
+struct fold_common_reference<std::void_t<typename common_reference<T, U>::type>,
+                             T,
+                             U,
+                             Ts...>
+    : common_reference<typename common_reference<T, U>::type, Ts...>
+{};
+} // namespace detail
+
+template<typename T, typename U, typename V, typename... Rest>
+struct common_reference<T, U, V, Rest...>
+    : detail::fold_common_reference<void, T, U, V, Rest...>
+{};
+
+template<typename... Ts>
+using common_reference_t = typename common_reference<Ts...>::type;
+} // namespace matter

--- a/include/matter/utility/decay_copy.hpp
+++ b/include/matter/utility/decay_copy.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+namespace matter
+{
+template<typename T>
+constexpr std::decay_t<T>
+decay_copy(T&& t) noexcept(noexcept(std::forward<T>(t)))
+{
+    return std::forward<T>(t);
+}
+} // namespace matter

--- a/include/matter/utility/priority_tag.hpp
+++ b/include/matter/utility/priority_tag.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstddef>
+
+namespace matter
+{
+template<std::size_t P>
+struct priority_tag : priority_tag<P - 1>
+{};
+
+template<>
+struct priority_tag<0>
+{};
+
+constexpr auto max_priority_tag = priority_tag<4>{};
+} // namespace matter

--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,7 @@ hana_proj = subproject('hana')
 
 range_v3_dep = dependency('range', fallback: ['range-v3', 'range_dep'])
 hana_dep = hana_proj.get_variable('hana_dep')
+hera_dep = dependency('hera', method: 'cmake', modules: ['hera::hera'])
 
 
 if get_option('build_tests')
@@ -27,7 +28,7 @@ endif
 
 matter_dep = declare_dependency(
   include_directories: matter_inc,
-  dependencies: [range_v3_dep, hana_dep],
+  dependencies: [range_v3_dep, hana_dep, hera_dep],
 )
 
 if get_option('build_tests')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,9 +1,9 @@
 option('build_tests',
        type: 'boolean',
-       value: false,
+       value: true,
        description: 'Build the unit tests')
 
 option('build_benchmarks',
        type: 'boolean',
-       value: false,
+       value: true,
        description: 'Build microbenchmarks')

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,17 +1,20 @@
 tests = [
-  'entt',
-  'registry',
-  'component',
-  'storage',
-  'util',
-  'erased',
-  'typed_id',
-  'algo',
-  'group_container',
-  'insert_buffer',
-  'id_cache',
-  'query',
-  'job',
+  'test_entt',
+  'test_registry',
+  'test_component',
+  'test_storage',
+  'test_util',
+  'test_erased',
+  'test_typed_id',
+  'test_algo',
+  'test_group_container',
+  'test_insert_buffer',
+  'test_id_cache',
+  'test_query',
+  'test_job',
+  'test_begin_end',
+  'test_soa',
+  'test_emplace_back'
 ]
 
 catch_lib = static_library(
@@ -23,7 +26,7 @@ catch_lib = static_library(
 foreach t : tests
   test_exe = executable(
     t,
-    'test_@0@.cpp'.format(t),
+    '@0@.cpp'.format(t),
     link_with: catch_lib,
     dependencies: [matter_dep, catch2_dep],
   )

--- a/test/test_begin_end.cpp
+++ b/test/test_begin_end.cpp
@@ -1,0 +1,96 @@
+#include <catch2/catch.hpp>
+
+#include "matter/iterator/begin.hpp"
+#include "matter/iterator/end.hpp"
+
+namespace my
+{
+struct adlable
+{
+    friend int* begin(adlable&) noexcept
+    {
+        return nullptr;
+    }
+
+    friend int* end(adlable&) noexcept
+    {
+        return nullptr;
+    }
+};
+} // namespace my
+
+TEST_CASE("begin")
+{
+    SECTION("array")
+    {
+        SECTION("nonconst")
+        {
+            int    arr[]  = {0, 1, 2, 3, 4, 5};
+            auto&& it     = matter::begin(arr);
+            auto&& end_it = matter::end(arr);
+            static_assert(std::is_same_v<int*, decltype(matter::begin(arr))>);
+            static_assert(std::is_same_v<int*, decltype(matter::end(arr))>);
+            static_assert(noexcept(matter::begin(arr)));
+            static_assert(noexcept(matter::end(arr)));
+            REQUIRE(*it == 0);
+            REQUIRE(*(end_it - 1) == 5);
+        }
+
+        SECTION("const")
+        {
+            const int arr[]  = {0, 1, 2, 3, 4, 5};
+            auto&&    it     = matter::begin(arr);
+            auto&&    end_it = matter::end(arr);
+            static_assert(
+                std::is_same_v<const int*, decltype(matter::begin(arr))>);
+            static_assert(
+                std::is_same_v<const int*, decltype(matter::end(arr))>);
+            REQUIRE(*it == 0);
+            REQUIRE(*(end_it - 1) == 5);
+        }
+
+        SECTION("rvalue")
+        {
+            // cannot call on rvalue array
+            int arr[] = {0, 1, 2, 3, 4, 5};
+            static_assert(!std::is_invocable_v<decltype(matter::begin),
+                                               decltype(std::move(arr))>);
+            static_assert(!std::is_invocable_v<decltype(matter::end),
+                                               decltype(std::move(arr))>);
+        }
+    }
+
+    SECTION("initializer_list")
+    {
+        SECTION("rvalue")
+        {
+            static_assert(!std::is_invocable_v<decltype(matter::begin),
+                                               std::initializer_list<int>&&>);
+            static_assert(!std::is_invocable_v<decltype(matter::end),
+                                               std::initializer_list<int>&&>);
+        }
+    }
+
+    SECTION("member")
+    {
+        std::vector<int> v{0, 1, 2, 3, 4, 5};
+
+        auto it     = matter::begin(v);
+        auto end_it = matter::end(v);
+
+        REQUIRE(*it == 0);
+        REQUIRE(*(end_it - 1) == 5);
+    }
+
+    SECTION("adl")
+    {
+        auto adl = my::adlable{};
+
+        auto it     = matter::begin(adl);
+        auto end_it = matter::end(adl);
+        static_assert(noexcept(matter::begin(adl)));
+        static_assert(noexcept(matter::end(adl)));
+        REQUIRE(it == nullptr);
+        REQUIRE(end_it == nullptr);
+    }
+}

--- a/test/test_emplace_back.cpp
+++ b/test/test_emplace_back.cpp
@@ -1,0 +1,69 @@
+#include <catch2/catch.hpp>
+
+#include "matter/container/emplace_back.hpp"
+
+#include <tuple>
+#include <vector>
+
+// should resolve through either push_back or construct value_type and then
+// push_back
+template<typename T>
+struct only_push_back : private std::vector<T>
+{
+    using std::vector<T>::vector;
+
+    constexpr auto& base() noexcept
+    {
+        return static_cast<std::vector<T>&>(*this);
+    }
+
+    decltype(auto) begin()
+    {
+        return base().begin();
+    }
+
+    template<typename U>
+    decltype(auto) push_back(U&& u)
+    {
+        return base().push_back(std::forward<U>(u));
+    }
+};
+
+namespace my
+{
+struct free_emplacer
+{
+    friend void emplace_back(free_emplacer&, int)
+    {}
+};
+} // namespace my
+
+TEST_CASE("emplace_back")
+{
+    SECTION("emplace_back_member")
+    {
+        auto vec = std::vector<int>{};
+
+        matter::emplace_back(vec, 5);
+    }
+
+    SECTION("emplace_back_free")
+    {
+        auto free = my::free_emplacer{};
+
+        matter::emplace_back(free, 1);
+    }
+
+    SECTION("push_back_direct")
+    {
+        auto pusher = only_push_back<int>{};
+
+        matter::emplace_back(pusher, 50);
+    }
+
+    SECTION("push_back_value_t")
+    {
+        auto pusher = only_push_back<std::tuple<int, int>>{};
+        matter::emplace_back(pusher, 5, 5);
+    }
+}

--- a/test/test_soa.cpp
+++ b/test/test_soa.cpp
@@ -1,0 +1,116 @@
+#include <catch2/catch.hpp>
+
+#include <hera/type_identity.hpp>
+
+#include "matter/container/soa.hpp"
+#include "matter/iterator/begin.hpp"
+
+template<matter::random_access_iterator I>
+constexpr void verify_it(I)
+{}
+
+template<matter::movable T>
+constexpr void verify_movable(T)
+{}
+
+TEST_CASE("soa")
+{
+    auto s = matter::soa<std::vector<int>, std::vector<float>>{
+        std::vector<int>{}, std::vector<float>{}};
+
+    // Does not compile because of the different keys requirement
+    // matter::soa<hera::pair<hera::type_identity<int>, std::vector<float>>,
+    //             hera::pair<hera::type_identity<int>, std::vector<int>>>{};
+
+    static_assert(decltype(s.has_value_type<float>())::value);
+    static_assert(decltype(s.has_value_type<int>())::value);
+    static_assert(!decltype(s.has_value_type<char>())::value);
+
+    REQUIRE(s.empty());
+    REQUIRE(s.size() == 0);
+
+    s.push_back(5, 5.0f);
+
+    REQUIRE(!s.empty());
+    REQUIRE(s.size() == 1);
+
+    // auto it = matter::begin(s);
+
+    SECTION("emplace_back")
+    {
+        REQUIRE(s.size() == 1);
+        s.emplace_back(hera::forward_as_tuple(5),
+                       hera::forward_as_tuple(42.0f));
+        REQUIRE(s.size() == 2);
+
+        auto [i1, f1] = *matter::begin(s);
+        REQUIRE(i1 == 5);
+        REQUIRE(f1 == 5.0f);
+
+        SECTION("erase")
+        {
+            s.erase(matter::begin(s));
+
+            auto [i2, f2] = *matter::begin(s);
+
+            REQUIRE(i2 == 5);
+            REQUIRE(f2 == 42.0f);
+        }
+    }
+
+    SECTION("keys_ordered")
+    {
+
+        auto s2 = matter::soa{std::vector<uint8_t>{},
+                              std::vector<char>{},
+                              std::vector<int>{},
+                              std::vector<float>{}};
+
+        s2.push_back(42, 'b', 0, 5.0f);
+
+        auto beg1  = s2.begin();
+        auto beg11 = beg1;
+        ++beg1;
+        ++beg1;
+        beg1 = beg11; // test copy assign
+
+        auto tup = hera::tuple{5, 4};
+        tup      = hera::tuple{42, 69};
+
+        verify_it(std::vector<int>::iterator{});
+
+        // verify_movable(hera::tuple{1, 1});
+        verify_it(beg1);
+
+        auto all_prox      = *beg1;
+        auto [u8, c, i, f] = all_prox;
+        REQUIRE(u8 == 42);
+        REQUIRE(c == 'b');
+        REQUIRE(i == 0);
+        REQUIRE(f == 5.0f);
+        static_assert(std::is_lvalue_reference_v<decltype(u8)>);
+        static_assert(std::is_lvalue_reference_v<decltype(c)>);
+        static_assert(std::is_lvalue_reference_v<decltype(i)>);
+        static_assert(std::is_lvalue_reference_v<decltype(f)>);
+
+        auto beg2   = s2.begin(hera::type_identity<uint8_t>{});
+        auto [u8_2] = *beg2;
+        static_assert(matter::same_as<uint8_t&, decltype(u8_2)>);
+
+        REQUIRE(u8_2 == 42);
+
+        auto&& [m_u8, m_c, m_i, m_f] = matter::iter_move(beg1);
+
+        static_assert(std::is_rvalue_reference_v<decltype(m_u8)>);
+        static_assert(std::is_rvalue_reference_v<decltype(m_c)>);
+        static_assert(std::is_rvalue_reference_v<decltype(m_i)>);
+        static_assert(std::is_rvalue_reference_v<decltype(m_f)>);
+
+        auto end1 = s2.end();
+        REQUIRE(end1 == ++beg1);
+
+        auto end2 = s2.end(hera::type_identity<uint8_t>{});
+
+        REQUIRE(end2 == ++beg2);
+    }
+}


### PR DESCRIPTION
This is the first step to simplifying the groups structure. Whilst previously, all component stores were stored in an array and is basically using this as a little trick to avoid a lot of template instantiation. This technique is quite hard to get a handle on and it would be better to replace them with polymorphism storing an soa. This will be that SoA and is the first step to simplifying the groups.